### PR TITLE
fix: Alpine Docker images + multi-arch builds

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,8 +8,9 @@ WORKDIR /app
 RUN apk add --no-cache wget
 
 # Install dependencies
+# Use --legacy-peer-deps for React 19 + Tremor (requires React 18) compatibility
 COPY package*.json ./
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 # Copy application code
 COPY . .


### PR DESCRIPTION
## Summary
- Switch backend Docker images from Debian to Alpine (fixes CVE scan failures)
- Add multi-arch Docker builds (amd64 + arm64) for ARM deployment support

## Test plan
- [ ] CI passes all checks
- [ ] Docker images build successfully for both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)