### PR TITLE
fix: update admin security test path after file move

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,7 +573,7 @@ jobs:
           # These tests are critical security validation
           # -n0 disables xdist parallelization
           # --timeout=0 disables timeout (fixture import takes >1s in CI)
-          pytest backend/tests/unit/test_admin_api.py \
+          pytest backend/tests/integration/test_admin_api.py \
             -n0 \
             --timeout=0 \
             -k "requires_debug_mode" \


### PR DESCRIPTION
## Summary
- Fix CI workflow path for `test_admin_api.py` (moved from `unit/` to `integration/`)

## Root Cause
The `Admin Endpoint Security Validation` CI job was failing because it referenced `backend/tests/unit/test_admin_api.py`, but this file was moved to `backend/tests/integration/test_admin_api.py` in a recent commit.

## Test plan
- [ ] CI `Admin Endpoint Security Validation` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)