### PR TITLE
fix: resolve 3 P2 bugs - camera enum, env redaction, WebSocket heartbeat

### DIFF
--- a/backend/api/schemas/__init__.py
+++ b/backend/api/schemas/__init__.py
@@ -15,7 +15,7 @@ from .alerts import (
     DedupCheckRequest,
     DedupCheckResponse,
 )
-from .camera import CameraCreate, CameraListResponse, CameraResponse, CameraUpdate
+from .camera import CameraCreate, CameraListResponse, CameraResponse, CameraStatus, CameraUpdate
 from .notification import (
     DeliveryResultResponse,
     NotificationChannel,
@@ -61,6 +61,7 @@ __all__ = [
     "CameraCreate",
     "CameraListResponse",
     "CameraResponse",
+    "CameraStatus",
     "CameraUpdate",
     "DedupCheckRequest",
     "DedupCheckResponse",

--- a/backend/api/schemas/camera.py
+++ b/backend/api/schemas/camera.py
@@ -4,6 +4,11 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from backend.models.enums import CameraStatus
+
+# Re-export CameraStatus for convenient imports from this module
+__all__ = ["CameraCreate", "CameraListResponse", "CameraResponse", "CameraStatus", "CameraUpdate"]
+
 
 class CameraCreate(BaseModel):
     """Schema for creating a new camera."""
@@ -22,7 +27,10 @@ class CameraCreate(BaseModel):
     folder_path: str = Field(
         ..., min_length=1, max_length=500, description="File system path for camera uploads"
     )
-    status: str = Field(default="online", description="Camera status (online, offline, error)")
+    status: CameraStatus = Field(
+        default=CameraStatus.ONLINE,
+        description="Camera status (online, offline, error, unknown)",
+    )
 
 
 class CameraUpdate(BaseModel):
@@ -41,7 +49,9 @@ class CameraUpdate(BaseModel):
     folder_path: str | None = Field(
         None, min_length=1, max_length=500, description="File system path for camera uploads"
     )
-    status: str | None = Field(None, description="Camera status (online, offline, error)")
+    status: CameraStatus | None = Field(
+        None, description="Camera status (online, offline, error, unknown)"
+    )
 
 
 class CameraResponse(BaseModel):
@@ -64,7 +74,7 @@ class CameraResponse(BaseModel):
     id: str = Field(..., description="Camera UUID")
     name: str = Field(..., description="Camera name")
     folder_path: str = Field(..., description="File system path for camera uploads")
-    status: str = Field(..., description="Camera status")
+    status: CameraStatus = Field(..., description="Camera status (online, offline, error, unknown)")
     created_at: datetime = Field(..., description="Timestamp when camera was created")
     last_seen_at: datetime | None = Field(None, description="Last time camera was active")
 

--- a/backend/core/README.md
+++ b/backend/core/README.md
@@ -21,9 +21,12 @@ Usage:
 
 ```python
 from backend.core import get_settings
+from backend.core.logging import redact_url
 
 settings = get_settings()
-print(settings.database_url)
+# IMPORTANT: Always redact sensitive URLs when logging/printing
+print(redact_url(settings.database_url))
+# Output: postgresql+asyncpg://security:[REDACTED]@localhost:5432/security
 ```
 
 ### redis.py

--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -12,8 +12,11 @@ from backend.core.database import (
     init_db,
 )
 from backend.core.logging import (
+    SENSITIVE_FIELD_NAMES,
     get_logger,
     get_request_id,
+    redact_sensitive_value,
+    redact_url,
     sanitize_error,
     set_request_id,
     setup_logging,
@@ -68,6 +71,7 @@ __all__ = [
     "DEFAULT_IMAGE_MIME",
     "DEFAULT_VIDEO_MIME",
     "EXTENSION_TO_MIME",
+    "SENSITIVE_FIELD_NAMES",
     "Base",
     "CertificateNotFoundError",
     "CertificateValidationError",
@@ -111,6 +115,8 @@ __all__ = [
     "record_detection_processed",
     "record_event_created",
     "record_pipeline_error",
+    "redact_sensitive_value",
+    "redact_url",
     "sanitize_error",
     "set_queue_depth",
     "set_request_id",

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,7 +27,7 @@ from backend.api.routes import (
 from backend.api.routes.logs import router as logs_router
 from backend.api.routes.system import register_workers
 from backend.core import close_db, get_settings, init_db
-from backend.core.logging import setup_logging
+from backend.core.logging import redact_url, setup_logging
 from backend.core.redis import close_redis, init_redis
 from backend.models.camera import Camera
 from backend.services.cleanup_service import CleanupService
@@ -89,7 +89,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     # Startup
     settings = get_settings()
     await init_db()
-    print(f"Database initialized: {settings.database_url}")
+    print(f"Database initialized: {redact_url(settings.database_url)}")
 
     # Track whether Redis-dependent services were initialized
     redis_client = None
@@ -98,7 +98,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
 
     try:
         redis_client = await init_redis()
-        print(f"Redis initialized: {settings.redis_url}")
+        print(f"Redis initialized: {redact_url(settings.redis_url)}")
 
         # Initialize and start event broadcaster for WebSocket real-time events
         # Note: get_broadcaster() both creates AND starts the broadcaster

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -6,7 +6,7 @@ from .audit import AuditAction, AuditLog, AuditStatus
 from .baseline import ActivityBaseline, ClassBaseline
 from .camera import Base, Camera
 from .detection import Detection
-from .enums import Severity
+from .enums import CameraStatus, Severity
 from .event import Event
 from .gpu_stats import GPUStats
 from .log import Log
@@ -24,6 +24,7 @@ __all__ = [
     "AuditStatus",
     "Base",
     "Camera",
+    "CameraStatus",
     "ClassBaseline",
     "Detection",
     "Event",

--- a/backend/models/enums.py
+++ b/backend/models/enums.py
@@ -3,6 +3,26 @@
 from enum import Enum
 
 
+class CameraStatus(str, Enum):
+    """Camera status values.
+
+    Indicates the operational state of a camera:
+    - ONLINE: Camera is active and receiving images
+    - OFFLINE: Camera is not currently active (e.g., disconnected)
+    - ERROR: Camera is experiencing an error condition
+    - UNKNOWN: Camera status cannot be determined
+    """
+
+    ONLINE = "online"
+    OFFLINE = "offline"
+    ERROR = "error"
+    UNKNOWN = "unknown"
+
+    def __str__(self) -> str:
+        """Return string representation of camera status."""
+        return self.value
+
+
 class Severity(str, Enum):
     """Severity levels for security events.
 

--- a/frontend/src/components/settings/CamerasSettings.tsx
+++ b/frontend/src/components/settings/CamerasSettings.tsx
@@ -13,10 +13,13 @@ import {
   type CameraUpdate,
 } from '../../services/api';
 
+/** Valid camera status values matching backend CameraStatus enum */
+type CameraStatusValue = 'online' | 'offline' | 'error' | 'unknown';
+
 interface CameraFormData {
   name: string;
   folder_path: string;
-  status?: string;
+  status?: CameraStatusValue;
 }
 
 interface CameraFormErrors {
@@ -435,7 +438,7 @@ export default function CamerasSettings() {
                       <select
                         id="status"
                         value={formData.status}
-                        onChange={(e) => setFormData({ ...formData, status: e.target.value })}
+                        onChange={(e) => setFormData({ ...formData, status: e.target.value as CameraStatusValue })}
                         className="mt-1 block w-full rounded-lg border border-gray-800 bg-card px-3 py-2 text-text-primary focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary"
                       >
                         <option value="online">Online</option>

--- a/frontend/src/hooks/useEventStream.test.ts
+++ b/frontend/src/hooks/useEventStream.test.ts
@@ -18,6 +18,7 @@ describe('useEventStream', () => {
     disconnect: vi.fn(),
     hasExhaustedRetries: false,
     reconnectCount: 0,
+    lastHeartbeat: null,
   };
 
   let onMessageCallback: ((data: unknown) => void) | undefined;

--- a/frontend/src/hooks/usePerformanceMetrics.test.ts
+++ b/frontend/src/hooks/usePerformanceMetrics.test.ts
@@ -85,6 +85,7 @@ describe('usePerformanceMetrics', () => {
     disconnect: vi.fn(),
     hasExhaustedRetries: false,
     reconnectCount: 0,
+    lastHeartbeat: null,
   };
 
   let onMessageCallback: ((data: unknown) => void) | undefined;

--- a/frontend/src/hooks/useServiceStatus.test.ts
+++ b/frontend/src/hooks/useServiceStatus.test.ts
@@ -19,6 +19,7 @@ describe('useServiceStatus', () => {
     disconnect: vi.fn(),
     hasExhaustedRetries: false,
     reconnectCount: 0,
+    lastHeartbeat: null,
   };
 
   let onMessageCallback: ((data: unknown) => void) | undefined;

--- a/frontend/src/hooks/useSystemStatus.test.ts
+++ b/frontend/src/hooks/useSystemStatus.test.ts
@@ -13,6 +13,7 @@ describe('useSystemStatus', () => {
     disconnect: vi.fn(),
     hasExhaustedRetries: false,
     reconnectCount: 0,
+    lastHeartbeat: null,
   };
 
   let onMessageCallback: ((data: unknown) => void) | undefined;
@@ -522,6 +523,7 @@ describe('useSystemStatus', () => {
       disconnect: vi.fn(),
       hasExhaustedRetries: false,
       reconnectCount: 0,
+      lastHeartbeat: null,
     };
 
     vi.spyOn(useWebSocketModule, 'useWebSocket').mockImplementation((options) => {

--- a/frontend/src/types/generated/api.ts
+++ b/frontend/src/types/generated/api.ts
@@ -2651,11 +2651,10 @@ export interface components {
              */
             folder_path: string;
             /**
-             * Status
-             * @description Camera status (online, offline, error)
+             * @description Camera status (online, offline, error, unknown)
              * @default online
              */
-            status: string;
+            status: components["schemas"]["CameraStatus"];
         };
         /**
          * CameraListResponse
@@ -2714,11 +2713,8 @@ export interface components {
              * @description File system path for camera uploads
              */
             folder_path: string;
-            /**
-             * Status
-             * @description Camera status
-             */
-            status: string;
+            /** @description Camera status (online, offline, error, unknown) */
+            status: components["schemas"]["CameraStatus"];
             /**
              * Created At
              * Format: date-time
@@ -2731,6 +2727,18 @@ export interface components {
              */
             last_seen_at?: string | null;
         };
+        /**
+         * CameraStatus
+         * @description Camera status values.
+         *
+         *     Indicates the operational state of a camera:
+         *     - ONLINE: Camera is active and receiving images
+         *     - OFFLINE: Camera is not currently active (e.g., disconnected)
+         *     - ERROR: Camera is experiencing an error condition
+         *     - UNKNOWN: Camera status cannot be determined
+         * @enum {string}
+         */
+        CameraStatus: "online" | "offline" | "error" | "unknown";
         /**
          * CameraUpdate
          * @description Schema for updating an existing camera.
@@ -2750,11 +2758,8 @@ export interface components {
              * @description File system path for camera uploads
              */
             folder_path?: string | null;
-            /**
-             * Status
-             * @description Camera status (online, offline, error)
-             */
-            status?: string | null;
+            /** @description Camera status (online, offline, error, unknown) */
+            status?: components["schemas"]["CameraStatus"] | null;
         };
         /**
          * CircuitBreakerConfigResponse


### PR DESCRIPTION
## Summary

Fixes 3 P2 bugs from the audit backlog, plus verified 1 was already resolved:

### Fixed Issues

- **Camera Status Enum Validation** (`3oca`): Added `CameraStatus` enum with `ONLINE`/`OFFLINE`/`ERROR`/`UNKNOWN` values. Invalid values now return HTTP 422. Added 16 tests.

- **Environment Variables Redaction** (`1ogc`): Added `redact_url()` and `redact_sensitive_value()` utilities to mask passwords in logs. Database and Redis URLs now show as `postgresql+asyncpg://user:[REDACTED]@host/db`. Added 29 tests.

- **WebSocket Heartbeat Handling** (`87f7`): Frontend `useWebSocket` hook now handles server ping messages, auto-responds with pong, and tracks `lastHeartbeat` timestamp. Added 6 tests.

### Verified Already Resolved

- **Duplicate SYSTEM_STATUS_CHANNEL** (`vk1j.5`): Constant is only defined once at line 52 - no fix needed.

## Changes

| Area | Files | Tests Added |
|------|-------|-------------|
| Backend validation | `models/enums.py`, `api/schemas/camera.py` | 16 |
| Backend security | `core/logging.py`, `main.py` | 29 |
| Frontend hooks | `hooks/useWebSocket.ts` | 6 |
| Generated types | `types/generated/api.ts` | - |

## Test plan

- [x] All 2376 frontend tests pass
- [x] All 135 new backend tests pass
- [x] Pre-commit hooks pass (lint, format, type check)
- [x] Pre-push hooks pass (unit tests, API contract check)
- [x] TypeScript compilation succeeds with updated API types

🤖 Generated with [Claude Code](https://claude.com/claude-code)