### PR TITLE
fix(ci): mark slow property test with @pytest.mark.slow

### DIFF
--- a/backend/tests/unit/models/test_alert.py
+++ b/backend/tests/unit/models/test_alert.py
@@ -692,6 +692,7 @@ class TestAlertProperties:
         alert = Alert(event_id=event_id, dedup_key="key")
         assert alert.event_id == event_id
 
+    @pytest.mark.slow
     @given(dedup_key=st.text(min_size=1, max_size=255))
     @settings(max_examples=25)
     def test_alert_dedup_key_roundtrip(self, dedup_key: str):


### PR DESCRIPTION
## Summary
Mark `test_alert_dedup_key_roundtrip` as slow to use 60s threshold instead of 1s.

This test is a hypothesis property-based test that generates text which inherently takes >1s.

## Fixes
- Test Performance Audit CI failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)