### PR TITLE
fix(ci): add slow test pattern to audit script

### DIFF
--- a/scripts/audit-test-durations.py
+++ b/scripts/audit-test-durations.py
@@ -39,6 +39,8 @@ SLOW_TEST_PATTERNS = [
     r"test_system_broadcaster.*restarts_with_fresh",
     # Media route tests (thumbnail generation)
     r"test_media_api.*test_compat_thumbnail",
+    # Property-based tests with text generation overhead
+    r"test_alert.*test_alert_dedup_key_roundtrip",
 ]
 
 


### PR DESCRIPTION
## Summary
Add `test_alert_dedup_key_roundtrip` to `SLOW_TEST_PATTERNS` in the audit script.

This hypothesis property test inherently takes >1s due to text generation overhead.

## Fixes
- Test Performance Audit CI failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)