### PR TITLE
feat: migrate issue tracking from beads to Linear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ coverage.json
 # Worktrees
 .worktrees/
 .hypothesis/
+.mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,88 +98,73 @@ uv run mypy backend        # Run type checker
 
 ## Issue Tracking
 
-This project uses **bd** (beads) for issue tracking:
+This project uses **Linear** for issue tracking:
+
+- **Workspace:** [nemotron-v3-home-security](https://linear.app/nemotron-v3-home-security)
+- **Team:** NEM
 
 ```bash
-bd ready                    # Find available work
-bd show <id>               # View task details
-bd update <id> --status in_progress  # Claim work
-bd close <id>              # Complete work
-bd sync                    # Sync with git
+# View active issues
+# https://linear.app/nemotron-v3-home-security/team/NEM/active
+
+# Filter by label (e.g., phase-1)
+# https://linear.app/nemotron-v3-home-security/team/NEM/label/phase-1
 ```
+
+Issues are organized with:
+
+- **Priorities:** Urgent, High, Medium, Low (mapped from P0-P4)
+- **Labels:** phase-1 through phase-8, backend, frontend, tdd, etc.
+- **Parent/sub-issues:** Epics contain sub-tasks
 
 ## Task Execution Order
 
 Tasks are organized into 8 execution phases. **Always complete earlier phases before starting later ones.**
 
-### Phase 1: Project Setup (P0) - 7 tasks
+### Phase 1: Project Setup (P0)
 
 Foundation - directory structures, container setup, environment, dependencies.
+[View in Linear](https://linear.app/nemotron-v3-home-security/team/NEM/label/phase-1)
 
-```bash
-bd list --label phase-1
-```
-
-### Phase 2: Database & Layout Foundation (P1) - 6 tasks
+### Phase 2: Database & Layout Foundation (P1)
 
 PostgreSQL models, Redis connection, Tailwind theme, app layout.
+[View in Linear](https://linear.app/nemotron-v3-home-security/team/NEM/label/phase-2)
 
-```bash
-bd list --label phase-2
-```
-
-### Phase 3: Core APIs & Components (P2) - 11 tasks
+### Phase 3: Core APIs & Components (P2)
 
 Cameras API, system API, WebSocket hooks, API client, basic UI components.
+[View in Linear](https://linear.app/nemotron-v3-home-security/team/NEM/label/phase-3)
 
-```bash
-bd list --label phase-3
-```
-
-### Phase 4: AI Pipeline (P3/P4) - 13 tasks
+### Phase 4: AI Pipeline (P3/P4)
 
 File watcher, RT-DETRv2 wrapper, detector client, batch aggregator, Nemotron analyzer.
+[View in Linear](https://linear.app/nemotron-v3-home-security/team/NEM/label/phase-4)
 
-```bash
-bd list --label phase-4
-```
-
-### Phase 5: Events & Real-time (P4) - 9 tasks
+### Phase 5: Events & Real-time (P4)
 
 Events API, detections API, WebSocket channels, GPU monitor, cleanup service.
+[View in Linear](https://linear.app/nemotron-v3-home-security/team/NEM/label/phase-5)
 
-```bash
-bd list --label phase-5
-```
-
-### Phase 6: Dashboard Components (P3) - 7 tasks
+### Phase 6: Dashboard Components (P3)
 
 Risk gauge, camera grid, live activity feed, GPU stats, EventCard.
+[View in Linear](https://linear.app/nemotron-v3-home-security/team/NEM/label/phase-6)
 
-```bash
-bd list --label phase-6
-```
-
-### Phase 7: Pages & Modals (P4) - 6 tasks
+### Phase 7: Pages & Modals (P4)
 
 Main dashboard, event timeline, event detail modal, settings pages.
+[View in Linear](https://linear.app/nemotron-v3-home-security/team/NEM/label/phase-7)
 
-```bash
-bd list --label phase-7
-```
-
-### Phase 8: Integration & E2E (P4) - 8 tasks
+### Phase 8: Integration & E2E (P4)
 
 Unit tests, E2E tests, deployment verification, documentation.
-
-```bash
-bd list --label phase-8
-```
+[View in Linear](https://linear.app/nemotron-v3-home-security/team/NEM/label/phase-8)
 
 ## Post-MVP Roadmap (After MVP is Operational)
 
 After the MVP is **fully operational end-to-end** (Phases 1–8 complete, deployment verified, and tests passing),
-review `docs/ROADMAP.md` to identify post-MVP enhancements and create/claim new beads tasks accordingly.
+review `docs/ROADMAP.md` to identify post-MVP enhancements and create new Linear issues accordingly.
 
 ## TDD Approach
 
@@ -204,7 +189,7 @@ This project follows **Test-Driven Development (TDD)** for all feature implement
 
 Before writing any production code, complete this checklist:
 
-- [ ] Understand the acceptance criteria from the bead
+- [ ] Understand the acceptance criteria from the Linear issue
 - [ ] Identify the code layer(s) involved (API, service, component, E2E)
 - [ ] Write test stubs for each acceptance criterion
 - [ ] Run tests to confirm they fail (RED phase)
@@ -376,22 +361,19 @@ This skill will:
 3. Guide you through the RED-GREEN-REFACTOR cycle
 4. Ensure proper test coverage before completion
 
-### Integration with Beads
+### Integration with Linear
 
 Tasks labeled `tdd` are test-focused tasks that pair with feature tasks:
+[View TDD issues](https://linear.app/nemotron-v3-home-security/team/NEM/label/tdd)
 
-```bash
-bd list --label tdd
-```
-
-**Workflow for TDD-labeled beads:**
+**Workflow for TDD-labeled issues:**
 
 1. **Claim both tasks** - The feature task and its corresponding TDD task
-2. **Start with tests** - Implement tests from the TDD bead first
+2. **Start with tests** - Implement tests from the TDD issue first
 3. **Verify RED** - Run tests to confirm they fail appropriately
 4. **Implement feature** - Write code to make tests pass (GREEN)
 5. **Refactor** - Clean up while keeping tests green
-6. **Close TDD bead first** - Then close the feature bead
+6. **Close TDD issue first** - Then close the feature issue
 
 ### Test Coverage Requirements
 
@@ -699,28 +681,28 @@ docs/plans/            # Design and implementation docs
 
 ## Session Workflow
 
-1. Check available work: `bd ready`
-2. Filter by current phase: `bd list --label phase-N`
-3. Claim task: `bd update <id> --status in_progress`
+1. Check available work in [Linear Active view](https://linear.app/nemotron-v3-home-security/team/NEM/active)
+2. Filter by label (e.g., phase-1, backend, frontend)
+3. Claim task by assigning to yourself and setting status to "In Progress"
 4. Implement following TDD (test first for `tdd` labeled tasks)
 5. Validate before closing: run `./scripts/validate.sh`
-6. Close task: `bd close <id>`
-7. End session: `bd sync && git push`
+6. Close task by setting status to "Done" in Linear
+7. End session: `git push`
 
 ## One-Task-One-PR Policy
 
-Each bead should result in exactly one PR:
+Each Linear issue should result in exactly one PR:
 
-- **PR title format:** `<type>: <bead title> (<bead-id>)`
-- **Example:** `fix: resolve WebSocket broadcast error (yzuz.7)`
+- **PR title format:** `<type>: <issue title> (NEM-<id>)`
+- **Example:** `fix: resolve WebSocket broadcast error (NEM-123)`
 
 **Anti-patterns (do not do):**
 
-| Bad PR Title                        | Problem                   |
-| ----------------------------------- | ------------------------- |
-| "fix: resolve 9 beads"              | Split into 9 PRs          |
-| "fix: resolve 20 production issues" | Create 20 beads, 20 PRs   |
-| "feat: X AND Y"                     | Split into separate beads |
+| Bad PR Title                        | Problem                    |
+| ----------------------------------- | -------------------------- |
+| "fix: resolve 9 issues"             | Split into 9 PRs           |
+| "fix: resolve 20 production issues" | Create 20 issues, 20 PRs   |
+| "feat: X AND Y"                     | Split into separate issues |
 
 **Exceptions:**
 
@@ -734,9 +716,9 @@ Each bead should result in exactly one PR:
 - Better code review quality (smaller, focused diffs)
 - Regressions are easier to identify and bisect
 
-## Bead Closure Requirements
+## Issue Closure Requirements
 
-Before running `bd close <id>`, verify ALL of the following:
+Before marking an issue as "Done" in Linear, verify ALL of the following:
 
 ### Required Checklist
 
@@ -763,7 +745,7 @@ cd frontend && npx playwright test  # E2E tests (multi-browser)
 
 1. Ensure all code is committed and pushed
 2. Run validation: `./scripts/validate.sh`
-3. If all tests pass, close the bead: `bd close <id>`
+3. If all tests pass, mark the issue as "Done" in Linear
 4. If tests fail, fix the issue and re-run before closing
 
-**CRITICAL:** Do not close a bead if any validation fails. Fix the issue first.
+**CRITICAL:** Do not close an issue if any validation fails. Fix the issue first.

--- a/docs/LINEAR_SETUP_PROMPT.md
+++ b/docs/LINEAR_SETUP_PROMPT.md
@@ -1,0 +1,109 @@
+# Linear Integration Setup Prompt
+
+Copy and paste this prompt to another Claude Code agent to configure Linear integration on a new workstation.
+
+---
+
+## Prompt
+
+I need you to set up Linear integration for this project. Here are the details:
+
+### Linear Workspace
+
+- **Workspace:** nemotron-v3-home-security
+- **Team:** NEM
+- **API Key:** `YOUR_LINEAR_API_KEY`
+
+### Tasks to Complete
+
+#### 1. Add LINEAR_API_KEY to shell profile
+
+Add the API key to `~/.bashrc` (or `~/.zshrc` on macOS):
+
+```bash
+echo 'export LINEAR_API_KEY="YOUR_LINEAR_API_KEY"' >> ~/.bashrc
+```
+
+#### 2. Install the Linear Claude Code skill
+
+```bash
+mkdir -p ~/.claude/skills
+git clone https://github.com/wrsmith108/linear-claude-skill ~/.claude/skills/linear
+cd ~/.claude/skills/linear && npm install
+```
+
+#### 3. Verify the skill installation
+
+```bash
+export LINEAR_API_KEY="YOUR_LINEAR_API_KEY"
+npx tsx ~/.claude/skills/linear/skills/linear/scripts/linear-ops.ts whoami
+```
+
+Expected output should show:
+
+- Name: Mike Svoboda
+- Organization: nemotron-v3-home-security
+- Team: Nemotron-v3-home-security (NEM)
+
+#### 4. Create project-level MCP configuration
+
+Create `.mcp.json` in the project root with:
+
+```json
+{
+  "mcpServers": {
+    "linear": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://mcp.linear.app/sse"],
+      "env": {
+        "LINEAR_API_KEY": "YOUR_LINEAR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+#### 5. Ensure .mcp.json is in .gitignore
+
+```bash
+grep -q "\.mcp\.json" .gitignore || echo ".mcp.json" >> .gitignore
+```
+
+### Verification
+
+After setup, these commands should work:
+
+```bash
+# Check Linear connection
+npx tsx ~/.claude/skills/linear/skills/linear/scripts/linear-ops.ts whoami
+
+# List active issues
+npx tsx ~/.claude/skills/linear/skills/linear/scripts/linear-ops.ts help
+```
+
+### Notes
+
+- The MCP server requires starting a **new Claude Code session** to load
+- Linear workspace URL: https://linear.app/nemotron-v3-home-security/team/NEM/active
+- The project's CLAUDE.md has already been updated to reference Linear instead of beads
+- All 1,031 issues have been migrated from beads to Linear
+
+---
+
+## Quick One-Liner Setup
+
+If you want a single command to run all setup steps:
+
+```bash
+# Add API key to bashrc
+echo 'export LINEAR_API_KEY="YOUR_LINEAR_API_KEY"' >> ~/.bashrc && \
+source ~/.bashrc && \
+# Install skill
+mkdir -p ~/.claude/skills && \
+git clone https://github.com/wrsmith108/linear-claude-skill ~/.claude/skills/linear && \
+cd ~/.claude/skills/linear && npm install && \
+# Verify
+npx tsx ~/.claude/skills/linear/skills/linear/scripts/linear-ops.ts whoami
+```
+
+Then manually create the `.mcp.json` file in each project that needs Linear access.

--- a/scripts/migrate_beads_to_linear.py
+++ b/scripts/migrate_beads_to_linear.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""
+Migrate beads issues to Linear.
+
+Usage:
+    export LINEAR_API_KEY="lin_api_..."
+    python scripts/migrate_beads_to_linear.py
+
+Or with explicit arguments:
+    python scripts/migrate_beads_to_linear.py --api-key "lin_api_..." --team-id "..."
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+# Linear API endpoint
+LINEAR_API_URL = "https://api.linear.app/graphql"
+
+# Team configuration
+DEFAULT_TEAM_ID = "998946a2-aa75-491b-a39d-189660131392"
+
+# Priority mapping: beads priority (1-4) -> Linear priority (1=urgent, 2=high, 3=medium, 4=low, 0=none)
+# Beads: P0=highest, P4=lowest (stored as 0-4)
+# Linear: 1=urgent, 2=high, 3=medium, 4=low, 0=no priority
+PRIORITY_MAP = {
+    0: 1,  # P0 -> Urgent
+    1: 2,  # P1 -> High
+    2: 3,  # P2 -> Medium
+    3: 4,  # P3 -> Low
+    4: 0,  # P4 -> No priority
+}
+
+# State mapping based on Linear's workflow states
+STATE_MAP = {
+    "open": "50ef9730-7d5e-43d6-b5e0-d7cac07af58f",  # Todo
+    "in_progress": "b88c8ae2-2545-4c1b-b83a-bf2dde2c03e7",  # In Progress
+    "closed": "38267c1e-4458-4875-aa66-4b56381786e9",  # Done
+}
+
+# Issue type to label mapping
+TYPE_LABEL_MAP = {
+    "bug": "Bug",
+    "feature": "Feature",
+    "task": None,  # No special label for tasks
+    "epic": None,  # Epics are handled via parent relationship
+}
+
+
+class LinearClient:
+    """Simple Linear GraphQL API client."""
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.client = httpx.Client(timeout=30.0)
+        self.label_cache: dict[str, str] = {}  # name -> id
+
+    def _request(self, query: str, variables: dict | None = None) -> dict:
+        """Execute a GraphQL request."""
+        response = self.client.post(
+            LINEAR_API_URL,
+            json={"query": query, "variables": variables or {}},
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": self.api_key,
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+        if "errors" in data:
+            raise Exception(f"GraphQL errors: {data['errors']}")
+        return data["data"]
+
+    def get_labels(self, team_id: str) -> dict[str, str]:
+        """Get existing labels for a team."""
+        query = """
+        query GetLabels($teamId: String!) {
+            team(id: $teamId) {
+                labels {
+                    nodes {
+                        id
+                        name
+                    }
+                }
+            }
+        }
+        """
+        data = self._request(query, {"teamId": team_id})
+        return {label["name"]: label["id"] for label in data["team"]["labels"]["nodes"]}
+
+    def create_label(self, team_id: str, name: str, color: str = "#6B7280") -> str | None:
+        """Create a new label and return its ID. Returns None if duplicate."""
+        query = """
+        mutation CreateLabel($teamId: String!, $name: String!, $color: String!) {
+            issueLabelCreate(input: {teamId: $teamId, name: $name, color: $color}) {
+                success
+                issueLabel {
+                    id
+                    name
+                }
+            }
+        }
+        """
+        try:
+            data = self._request(query, {"teamId": team_id, "name": name, "color": color})
+            if not data["issueLabelCreate"]["success"]:
+                return None
+            return data["issueLabelCreate"]["issueLabel"]["id"]
+        except Exception as e:
+            error_str = str(e).lower()
+            if "duplicate" in error_str:
+                return None  # Will be handled by looking up existing labels
+            if "reserved" in error_str:
+                # Try with a prefix for reserved names
+                return self.create_label(team_id, f"beads-{name}", color)
+            raise
+
+    def create_issue(
+        self,
+        team_id: str,
+        title: str,
+        description: str | None = None,
+        priority: int = 0,
+        state_id: str | None = None,
+        label_ids: list[str] | None = None,
+        parent_id: str | None = None,
+    ) -> dict:
+        """Create a new issue."""
+        query = """
+        mutation CreateIssue($input: IssueCreateInput!) {
+            issueCreate(input: $input) {
+                success
+                issue {
+                    id
+                    identifier
+                    title
+                    url
+                }
+            }
+        }
+        """
+        input_data: dict[str, Any] = {
+            "teamId": team_id,
+            "title": title,
+            "priority": priority,
+        }
+        if description:
+            input_data["description"] = description
+        if state_id:
+            input_data["stateId"] = state_id
+        if label_ids:
+            input_data["labelIds"] = label_ids
+        if parent_id:
+            input_data["parentId"] = parent_id
+
+        data = self._request(query, {"input": input_data})
+        if not data["issueCreate"]["success"]:
+            raise Exception(f"Failed to create issue: {title}")
+        return data["issueCreate"]["issue"]
+
+    def ensure_labels(self, team_id: str, labels: set[str]) -> dict[str, str]:
+        """Ensure all labels exist, creating missing ones."""
+        existing = self.get_labels(team_id)
+        self.label_cache.update(existing)
+
+        # Build case-insensitive lookup
+        existing_lower = {name.lower(): name for name in self.label_cache}
+
+        # Color palette for new labels
+        colors = [
+            "#EF4444",
+            "#F97316",
+            "#F59E0B",
+            "#EAB308",
+            "#84CC16",
+            "#22C55E",
+            "#10B981",
+            "#14B8A6",
+            "#06B6D4",
+            "#0EA5E9",
+            "#3B82F6",
+            "#6366F1",
+            "#8B5CF6",
+            "#A855F7",
+            "#D946EF",
+            "#EC4899",
+            "#F43F5E",
+        ]
+
+        for i, label in enumerate(sorted(labels)):
+            # Check case-insensitive match
+            if label.lower() in existing_lower:
+                # Map to the existing label's case
+                existing_name = existing_lower[label.lower()]
+                if label not in self.label_cache:
+                    self.label_cache[label] = self.label_cache[existing_name]
+                continue
+
+            if label not in self.label_cache:
+                color = colors[i % len(colors)]
+                print(f"  Creating label: {label}")
+                label_id = self.create_label(team_id, label, color)
+                if label_id:
+                    self.label_cache[label] = label_id
+                    existing_lower[label.lower()] = label
+                    # Check if it was renamed (prefixed)
+                    existing = self.get_labels(team_id)
+                    if f"beads-{label}" in existing:
+                        self.label_cache[label] = existing[f"beads-{label}"]
+                        print(f"    (renamed to beads-{label})")
+                else:
+                    # Refresh cache if creation failed (duplicate)
+                    print(f"  Label '{label}' already exists, refreshing cache...")
+                    existing = self.get_labels(team_id)
+                    self.label_cache.update(existing)
+                    existing_lower = {name.lower(): name for name in self.label_cache}
+                    if label.lower() in existing_lower:
+                        existing_name = existing_lower[label.lower()]
+                        self.label_cache[label] = self.label_cache[existing_name]
+                time.sleep(0.1)  # Rate limiting
+
+        return self.label_cache
+
+
+def load_beads(jsonl_path: Path) -> list[dict]:
+    """Load beads from JSONL export."""
+    beads = []
+    with open(jsonl_path) as f:
+        for line in f:
+            if line.strip():
+                beads.append(json.loads(line))
+    return beads
+
+
+def get_parent_id(bead: dict) -> str | None:
+    """Extract parent bead ID from dependencies."""
+    deps = bead.get("dependencies", [])
+    for dep in deps:
+        if dep.get("type") == "parent-child":
+            # The depends_on_id is the parent
+            parent_id = dep.get("depends_on_id")
+            if parent_id and parent_id != bead["id"]:
+                return parent_id
+    return None
+
+
+def build_description(bead: dict) -> str:
+    """Build Linear description from bead data."""
+    parts = []
+
+    # Original description
+    if bead.get("description"):
+        parts.append(bead["description"])
+
+    # Metadata footer
+    parts.append("\n---")
+    parts.append(f"*Migrated from beads: `{bead['id']}`*")
+
+    if bead.get("created_at"):
+        parts.append(f"*Original created: {bead['created_at'][:10]}*")
+
+    if bead.get("closed_at"):
+        parts.append(f"*Original closed: {bead['closed_at'][:10]}*")
+
+    return "\n".join(parts)
+
+
+def collect_labels(beads: list[dict]) -> set[str]:
+    """Collect all unique labels from beads."""
+    all_labels: set[str] = set()
+    for bead in beads:
+        all_labels.update(bead.get("labels", []))
+        issue_type = bead.get("issue_type", "task")
+        type_label = TYPE_LABEL_MAP.get(issue_type)
+        if type_label:
+            all_labels.add(type_label)
+    return all_labels
+
+
+def get_label_ids(bead: dict, label_map: dict[str, str]) -> list[str]:
+    """Get Linear label IDs for a bead."""
+    label_ids = [label_map[label] for label in bead.get("labels", []) if label in label_map]
+    issue_type = bead.get("issue_type", "task")
+    type_label = TYPE_LABEL_MAP.get(issue_type)
+    if type_label and type_label in label_map:
+        label_ids.append(label_map[type_label])
+    return label_ids
+
+
+def migrate_single_issue(
+    client: LinearClient,
+    team_id: str,
+    bead: dict,
+    label_map: dict[str, str],
+    parent_map: dict[str, str | None],
+    created: dict[str, str],
+) -> dict:
+    """Migrate a single bead to Linear and return the created issue."""
+    bead_id = bead["id"]
+    status = bead.get("status", "open")
+    state_id = STATE_MAP.get(status, STATE_MAP["open"])
+    priority = PRIORITY_MAP.get(bead.get("priority", 2), 3)
+    label_ids = get_label_ids(bead, label_map)
+    parent_bead_id = parent_map.get(bead_id)
+    parent_linear_id = created.get(parent_bead_id) if parent_bead_id else None
+
+    return client.create_issue(
+        team_id=team_id,
+        title=bead["title"],
+        description=build_description(bead),
+        priority=priority,
+        state_id=state_id,
+        label_ids=label_ids if label_ids else None,
+        parent_id=parent_linear_id,
+    )
+
+
+def migrate(
+    api_key: str,
+    team_id: str,
+    jsonl_path: Path,
+    dry_run: bool = False,
+    limit: int | None = None,
+    resume: bool = False,
+) -> None:
+    """Run the migration."""
+    print(f"Loading beads from {jsonl_path}...")
+    beads = load_beads(jsonl_path)
+    print(f"Loaded {len(beads)} beads")
+
+    # Load existing mapping if resuming
+    mapping_path = jsonl_path.parent / "beads_to_linear_mapping.json"
+    existing_mapping: dict[str, str] = {}
+    if resume and mapping_path.exists():
+        with open(mapping_path) as f:
+            existing_mapping = json.load(f)
+        print(f"Resuming: {len(existing_mapping)} issues already migrated")
+
+    if limit:
+        beads = beads[:limit]
+        print(f"Limited to {limit} beads for testing")
+
+    all_labels = collect_labels(beads)
+    print(f"\nFound {len(all_labels)} unique labels: {sorted(all_labels)}")
+
+    if dry_run:
+        print("\n[DRY RUN] Would create these issues:")
+        for bead in beads[:10]:
+            print(f"  - {bead['id']}: {bead['title'][:60]}...")
+        if len(beads) > 10:
+            print(f"  ... and {len(beads) - 10} more")
+        return
+
+    client = LinearClient(api_key)
+    print("\nEnsuring labels exist...")
+    label_map = client.ensure_labels(team_id, all_labels)
+    print(f"Label cache: {len(label_map)} labels ready")
+
+    # Build parent-child mapping and sort (parents first)
+    parent_map: dict[str, str | None] = {bead["id"]: get_parent_id(bead) for bead in beads}
+    beads_sorted = sorted(
+        beads,
+        key=lambda b: (1 if parent_map.get(b["id"]) else 0, len(b["id"]), b["id"]),
+    )
+
+    created: dict[str, str] = dict(existing_mapping)
+    failed: list[tuple[str, str]] = []
+    skipped = 0
+
+    print(f"\nMigrating {len(beads_sorted)} issues...")
+    for i, bead in enumerate(beads_sorted):
+        bead_id = bead["id"]
+        if bead_id in created:
+            skipped += 1
+            continue
+
+        try:
+            issue = migrate_single_issue(client, team_id, bead, label_map, parent_map, created)
+            created[bead_id] = issue["id"]
+            print(
+                f"[{i + 1}/{len(beads_sorted)}] Created {issue['identifier']}: {bead['title'][:50]}..."
+            )
+            time.sleep(0.15)
+        except Exception as e:
+            failed.append((bead_id, str(e)))
+            print(f"[{i + 1}/{len(beads_sorted)}] FAILED {bead_id}: {e}")
+
+    # Summary
+    print(f"\n{'=' * 60}")
+    print("Migration complete!")
+    print(f"  Created: {len(created) - len(existing_mapping)} new issues")
+    print(f"  Skipped: {skipped} already migrated")
+    print(f"  Failed: {len(failed)} issues")
+    print(f"  Total in Linear: {len(created)} issues")
+
+    if failed:
+        print("\nFailed issues:")
+        for bead_id, error in failed:
+            print(f"  - {bead_id}: {error}")
+
+    # Save mapping for reference
+    mapping_path = jsonl_path.parent / "beads_to_linear_mapping.json"
+    with open(mapping_path, "w") as f:
+        json.dump(created, f, indent=2)
+    print(f"\nMapping saved to: {mapping_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Migrate beads to Linear")
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("LINEAR_API_KEY"),
+        help="Linear API key (or set LINEAR_API_KEY env var)",
+    )
+    parser.add_argument(
+        "--team-id",
+        default=os.environ.get("LINEAR_TEAM_ID", DEFAULT_TEAM_ID),
+        help="Linear team ID",
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to beads JSONL export (run 'bd export > beads.jsonl' first)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be migrated without creating issues",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Limit number of issues to migrate (for testing)",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume from previous migration (skip already migrated issues)",
+    )
+
+    args = parser.parse_args()
+
+    if not args.api_key:
+        print("Error: LINEAR_API_KEY not set. Use --api-key or set the environment variable.")
+        sys.exit(1)
+
+    if not args.input.exists():
+        print(f"Error: Input file not found: {args.input}")
+        print("Run 'bd export > /tmp/beads_export.jsonl' first")
+        sys.exit(1)
+
+    migrate(
+        api_key=args.api_key,
+        team_id=args.team_id,
+        jsonl_path=args.input,
+        dry_run=args.dry_run,
+        limit=args.limit,
+        resume=args.resume,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Migrates issue tracking from beads (bd CLI) to Linear (linear.app)
- Adds migration script that transferred all 1,031 issues with labels, priorities, and parent-child relationships
- Updates CLAUDE.md to reference Linear workspace and workflows
- Adds setup documentation for configuring Linear on new workstations

## Changes

- **scripts/migrate_beads_to_linear.py**: Python script to migrate beads to Linear via GraphQL API
- **CLAUDE.md**: Updated issue tracking references from beads to Linear
- **docs/LINEAR_SETUP_PROMPT.md**: Setup instructions for new workstations
- **.gitignore**: Added .mcp.json (contains API key)

## Test plan

- [x] Migration script successfully migrated 1,031 issues
- [x] Labels, priorities, and parent-child relationships preserved
- [x] Linear skill installed and verified with `whoami` command
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)