### PR TITLE
feat: display AI enrichment data in event details (NEM-501)

### DIFF
--- a/backend/alembic/versions/add_enrichment_data_column.py
+++ b/backend/alembic/versions/add_enrichment_data_column.py
@@ -1,0 +1,38 @@
+"""Add enrichment_data column to detections table
+
+Revision ID: add_enrichment_data
+Revises: add_camera_unique_constraints
+Create Date: 2026-01-03 12:00:00.000000
+
+This migration adds the enrichment_data JSONB column to the detections table.
+The column stores AI enrichment data including:
+- Vehicle classification (type, color, damage)
+- Pet identification (type, breed)
+- Person attributes (clothing, action, carrying)
+- License plates (text, confidence)
+- Weather conditions
+- Image quality scores
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_enrichment_data"
+down_revision: str | Sequence[str] | None = "add_camera_unique_constraints"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add enrichment_data JSONB column to detections table."""
+    op.add_column("detections", sa.Column("enrichment_data", JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove enrichment_data column from detections table."""
+    op.drop_column("detections", "enrichment_data")

--- a/backend/api/schemas/detections.py
+++ b/backend/api/schemas/detections.py
@@ -1,6 +1,7 @@
 """Pydantic schemas for detections API endpoints."""
 
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -29,6 +30,20 @@ class DetectionResponse(BaseModel):
                 "video_codec": None,
                 "video_width": None,
                 "video_height": None,
+                "enrichment_data": {
+                    "vehicle": {
+                        "type": "sedan",
+                        "color": "blue",
+                        "damage": [],
+                        "confidence": 0.92,
+                    },
+                    "person": {
+                        "clothing": "dark jacket",
+                        "action": "walking",
+                        "carrying": "backpack",
+                        "confidence": 0.95,
+                    },
+                },
             }
         },
     )
@@ -53,6 +68,13 @@ class DetectionResponse(BaseModel):
     video_codec: str | None = Field(None, description="Video codec (e.g., h264, hevc)")
     video_width: int | None = Field(None, description="Video resolution width")
     video_height: int | None = Field(None, description="Video resolution height")
+
+    # AI enrichment data (vehicle classification, pet identification, etc.)
+    enrichment_data: dict[str, Any] | None = Field(
+        None,
+        description="AI enrichment data including vehicle classification, pet identification, "
+        "person attributes, license plates, weather, and image quality scores",
+    )
 
 
 class DetectionListResponse(BaseModel):

--- a/backend/models/detection.py
+++ b/backend/models/detection.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .camera import Base
@@ -53,6 +54,9 @@ class Detection(Base):
     video_codec: Mapped[str | None] = mapped_column(String, nullable=True)
     video_width: Mapped[int | None] = mapped_column(Integer, nullable=True)
     video_height: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # AI enrichment data (vehicle classification, pet identification, etc.)
+    enrichment_data: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     # Relationships
     camera: Mapped[Camera] = relationship("Camera", back_populates="detections")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -247,6 +247,9 @@ async def _reset_db_schema() -> None:
         # This handles schema drift without dropping data
         # Using IF NOT EXISTS makes this idempotent and safe to run in parallel
         await conn.execute(text("ALTER TABLE events ADD COLUMN IF NOT EXISTS llm_prompt TEXT"))
+        await conn.execute(
+            text("ALTER TABLE detections ADD COLUMN IF NOT EXISTS enrichment_data JSONB")
+        )
 
         # Add unique indexes for cameras table (migration adds these for production)
         # First, clean up any duplicate cameras that might prevent index creation

--- a/backend/tests/unit/api/routes/test_enrichment_storage.py
+++ b/backend/tests/unit/api/routes/test_enrichment_storage.py
@@ -1,0 +1,390 @@
+"""Unit tests for enrichment data storage and API retrieval.
+
+These tests verify that enrichment data (vehicle classification, pet identification,
+person attributes, license plates, etc.) is correctly persisted to detections
+and returned in API responses.
+
+Following TDD: These tests are written BEFORE implementation.
+"""
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+
+@pytest.fixture
+async def sample_camera_for_enrichment(test_db):
+    """Create a sample camera for enrichment tests."""
+    from backend.models.camera import Camera
+
+    async with test_db() as session:
+        camera = Camera(
+            id=str(uuid.uuid4()),
+            name=f"Enrichment Test Camera {uuid.uuid4().hex[:8]}",
+            folder_path=f"/export/foscam/enrichment_test_{uuid.uuid4().hex[:8]}",
+            status="online",
+        )
+        session.add(camera)
+        await session.commit()
+        await session.refresh(camera)
+        return camera
+
+
+@pytest.fixture
+def sample_enrichment_data():
+    """Sample enrichment data structure for tests."""
+    return {
+        "vehicle": {
+            "type": "sedan",
+            "color": "blue",
+            "damage": [],
+            "confidence": 0.92,
+        },
+        "pet": {
+            "type": "dog",
+            "breed": "labrador",
+            "confidence": 0.88,
+        },
+        "person": {
+            "clothing": "dark jacket",
+            "action": "walking",
+            "carrying": "backpack",
+            "confidence": 0.95,
+        },
+        "license_plate": {
+            "text": "ABC123",
+            "confidence": 0.91,
+        },
+        "weather": {
+            "condition": "cloudy",
+            "confidence": 0.87,
+        },
+        "image_quality": {
+            "score": 0.85,
+            "issues": [],
+        },
+    }
+
+
+class TestDetectionModelEnrichmentData:
+    """Tests for Detection model enrichment_data column."""
+
+    @pytest.mark.asyncio
+    async def test_detection_model_has_enrichment_data_column(
+        self, test_db, sample_camera_for_enrichment
+    ):
+        """Test that Detection model has enrichment_data column."""
+        from backend.models.detection import Detection
+
+        async with test_db() as session:
+            detection = Detection(
+                camera_id=sample_camera_for_enrichment.id,
+                file_path="/export/foscam/test/image.jpg",
+                file_type="image/jpeg",
+                detected_at=datetime.now(UTC),
+                object_type="person",
+                confidence=0.95,
+                bbox_x=100,
+                bbox_y=150,
+                bbox_width=200,
+                bbox_height=400,
+                enrichment_data=None,
+            )
+            session.add(detection)
+            await session.commit()
+            await session.refresh(detection)
+
+            assert hasattr(detection, "enrichment_data")
+            assert detection.enrichment_data is None
+
+    @pytest.mark.asyncio
+    async def test_detection_stores_enrichment_data_json(
+        self, test_db, sample_camera_for_enrichment, sample_enrichment_data
+    ):
+        """Test that enrichment data is stored as JSON in Detection model."""
+        from backend.models.detection import Detection
+
+        async with test_db() as session:
+            detection = Detection(
+                camera_id=sample_camera_for_enrichment.id,
+                file_path="/export/foscam/test/image.jpg",
+                file_type="image/jpeg",
+                detected_at=datetime.now(UTC),
+                object_type="car",
+                confidence=0.92,
+                bbox_x=300,
+                bbox_y=200,
+                bbox_width=400,
+                bbox_height=300,
+                enrichment_data=sample_enrichment_data,
+            )
+            session.add(detection)
+            await session.commit()
+            await session.refresh(detection)
+
+            # Verify enrichment_data is persisted correctly
+            assert detection.enrichment_data is not None
+            assert detection.enrichment_data["vehicle"]["type"] == "sedan"
+            assert detection.enrichment_data["pet"]["breed"] == "labrador"
+            assert detection.enrichment_data["license_plate"]["text"] == "ABC123"
+
+    @pytest.mark.asyncio
+    async def test_detection_enrichment_data_retrieved_from_database(
+        self, test_db, sample_camera_for_enrichment, sample_enrichment_data
+    ):
+        """Test that enrichment data is correctly retrieved from database."""
+        from sqlalchemy import select
+
+        from backend.models.detection import Detection
+
+        async with test_db() as session:
+            detection = Detection(
+                camera_id=sample_camera_for_enrichment.id,
+                file_path="/export/foscam/test/retrieve_test.jpg",
+                file_type="image/jpeg",
+                detected_at=datetime.now(UTC),
+                object_type="person",
+                confidence=0.95,
+                bbox_x=100,
+                bbox_y=150,
+                bbox_width=200,
+                bbox_height=400,
+                enrichment_data=sample_enrichment_data,
+            )
+            session.add(detection)
+            await session.commit()
+            detection_id = detection.id
+
+        # Retrieve in a new session to verify persistence
+        async with test_db() as session:
+            result = await session.execute(select(Detection).where(Detection.id == detection_id))
+            retrieved = result.scalar_one()
+
+            assert retrieved.enrichment_data is not None
+            assert retrieved.enrichment_data == sample_enrichment_data
+
+
+class TestDetectionResponseSchema:
+    """Tests for DetectionResponse schema enrichment_data field."""
+
+    def test_detection_response_includes_enrichment_data_field(self):
+        """Test that DetectionResponse schema has enrichment_data field."""
+        from backend.api.schemas.detections import DetectionResponse
+
+        schema_fields = DetectionResponse.model_fields
+        assert "enrichment_data" in schema_fields
+
+    def test_detection_response_serializes_enrichment_data(self, sample_enrichment_data):
+        """Test that DetectionResponse correctly serializes enrichment data."""
+        from datetime import datetime
+
+        from backend.api.schemas.detections import DetectionResponse
+
+        response = DetectionResponse(
+            id=1,
+            camera_id="test-camera",
+            file_path="/test/image.jpg",
+            file_type="image/jpeg",
+            detected_at=datetime.now(UTC),
+            object_type="person",
+            confidence=0.95,
+            bbox_x=100,
+            bbox_y=150,
+            bbox_width=200,
+            bbox_height=400,
+            thumbnail_path=None,
+            media_type="image",
+            duration=None,
+            video_codec=None,
+            video_width=None,
+            video_height=None,
+            enrichment_data=sample_enrichment_data,
+        )
+
+        # Convert to dict to verify serialization
+        response_dict = response.model_dump()
+        assert "enrichment_data" in response_dict
+        assert response_dict["enrichment_data"] == sample_enrichment_data
+
+    def test_detection_response_handles_null_enrichment_data(self):
+        """Test that DetectionResponse handles null enrichment data."""
+        from datetime import datetime
+
+        from backend.api.schemas.detections import DetectionResponse
+
+        response = DetectionResponse(
+            id=1,
+            camera_id="test-camera",
+            file_path="/test/image.jpg",
+            file_type="image/jpeg",
+            detected_at=datetime.now(UTC),
+            object_type="person",
+            confidence=0.95,
+            bbox_x=100,
+            bbox_y=150,
+            bbox_width=200,
+            bbox_height=400,
+            thumbnail_path=None,
+            media_type="image",
+            duration=None,
+            video_codec=None,
+            video_width=None,
+            video_height=None,
+            enrichment_data=None,
+        )
+
+        response_dict = response.model_dump()
+        assert response_dict["enrichment_data"] is None
+
+
+class TestDetectionsAPIEnrichmentData:
+    """Tests for Detections API endpoints returning enrichment data."""
+
+    @pytest.mark.asyncio
+    async def test_get_detection_returns_enrichment_data(
+        self, test_db, sample_camera_for_enrichment, sample_enrichment_data
+    ):
+        """Test that GET /api/detections/{id} returns enrichment_data."""
+        from httpx import ASGITransport, AsyncClient
+
+        from backend.main import app
+        from backend.models.detection import Detection
+
+        # Create detection with enrichment data
+        async with test_db() as session:
+            detection = Detection(
+                camera_id=sample_camera_for_enrichment.id,
+                file_path="/export/foscam/test/api_test.jpg",
+                file_type="image/jpeg",
+                detected_at=datetime.now(UTC),
+                object_type="car",
+                confidence=0.92,
+                bbox_x=300,
+                bbox_y=200,
+                bbox_width=400,
+                bbox_height=300,
+                enrichment_data=sample_enrichment_data,
+            )
+            session.add(detection)
+            await session.commit()
+            detection_id = detection.id
+
+        # Test API response
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(f"/api/detections/{detection_id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "enrichment_data" in data
+        assert data["enrichment_data"] == sample_enrichment_data
+
+    @pytest.mark.asyncio
+    async def test_list_detections_returns_enrichment_data(
+        self, test_db, sample_camera_for_enrichment, sample_enrichment_data
+    ):
+        """Test that GET /api/detections returns enrichment_data for each detection."""
+        from httpx import ASGITransport, AsyncClient
+
+        from backend.main import app
+        from backend.models.detection import Detection
+
+        # Create detection with enrichment data
+        async with test_db() as session:
+            detection = Detection(
+                camera_id=sample_camera_for_enrichment.id,
+                file_path="/export/foscam/test/list_api_test.jpg",
+                file_type="image/jpeg",
+                detected_at=datetime.now(UTC),
+                object_type="person",
+                confidence=0.95,
+                bbox_x=100,
+                bbox_y=150,
+                bbox_width=200,
+                bbox_height=400,
+                enrichment_data=sample_enrichment_data,
+            )
+            session.add(detection)
+            await session.commit()
+            camera_id = sample_camera_for_enrichment.id
+
+        # Test API response
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(f"/api/detections?camera_id={camera_id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "detections" in data
+        # Find our detection in the list
+        detection_found = False
+        for det in data["detections"]:
+            if (
+                "enrichment_data" in det
+                and det["enrichment_data"] is not None
+                and det["enrichment_data"].get("license_plate", {}).get("text") == "ABC123"
+            ):
+                detection_found = True
+                break
+        assert detection_found, "Detection with enrichment data not found in API response"
+
+
+class TestEventDetectionsEnrichmentData:
+    """Tests for event detections endpoint returning enrichment data."""
+
+    @pytest.mark.asyncio
+    async def test_get_event_detections_includes_enrichment_data(
+        self, test_db, sample_camera_for_enrichment, sample_enrichment_data
+    ):
+        """Test that GET /api/events/{id}/detections returns enrichment_data."""
+        from httpx import ASGITransport, AsyncClient
+
+        from backend.main import app
+        from backend.models.detection import Detection
+        from backend.models.event import Event
+
+        # Create detection with enrichment data
+        async with test_db() as session:
+            detection = Detection(
+                camera_id=sample_camera_for_enrichment.id,
+                file_path="/export/foscam/test/event_detection.jpg",
+                file_type="image/jpeg",
+                detected_at=datetime.now(UTC),
+                object_type="person",
+                confidence=0.95,
+                bbox_x=100,
+                bbox_y=150,
+                bbox_width=200,
+                bbox_height=400,
+                enrichment_data=sample_enrichment_data,
+            )
+            session.add(detection)
+            await session.commit()
+            detection_id = detection.id
+
+            # Create event referencing this detection
+            event = Event(
+                batch_id=str(uuid.uuid4()),
+                camera_id=sample_camera_for_enrichment.id,
+                started_at=datetime.now(UTC),
+                ended_at=datetime.now(UTC),
+                risk_score=50,
+                risk_level="medium",
+                summary="Test event with enrichment",
+                detection_ids=json.dumps([detection_id]),
+                reviewed=False,
+            )
+            session.add(event)
+            await session.commit()
+            event_id = event.id
+
+        # Test API response
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(f"/api/events/{event_id}/detections")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "detections" in data
+        assert len(data["detections"]) == 1
+        assert "enrichment_data" in data["detections"][0]
+        assert data["detections"][0]["enrichment_data"] == sample_enrichment_data

--- a/frontend/src/components/events/AGENTS.md
+++ b/frontend/src/components/events/AGENTS.md
@@ -14,6 +14,8 @@ Contains components for displaying, filtering, and interacting with security eve
 | `EventTimeline.test.tsx`    | Test suite for EventTimeline                |
 | `EventDetailModal.tsx`      | Full event detail modal                     |
 | `EventDetailModal.test.tsx` | Test suite for EventDetailModal             |
+| `EnrichmentPanel.tsx`       | AI enrichment data accordion display        |
+| `EnrichmentPanel.test.tsx`  | Test suite for EnrichmentPanel              |
 | `ThumbnailStrip.tsx`        | Detection thumbnail strip                   |
 | `ThumbnailStrip.test.tsx`   | Test suite for ThumbnailStrip               |
 | `ExportPanel.tsx`           | Event export with filters and format select |
@@ -189,6 +191,51 @@ interface Event {
   reviewed?: boolean;
   notes?: string | null;
   flagged?: boolean;
+}
+```
+
+### EnrichmentPanel.tsx
+
+**Purpose:** Displays AI enrichment data for detections in collapsible accordion sections
+
+**Key Features:**
+
+- Accordion sections for each enrichment type present
+- Confidence badges with color-coding (green >0.9, yellow 0.7-0.9, red <0.7)
+- Conditional rendering based on what enrichment data exists
+- Icons for each enrichment type (Car, Dog, User, CreditCard, Cloud, ImageIcon)
+- Clean, readable layout matching existing Tremor/Tailwind styling
+
+**Enrichment Types:**
+
+- **Vehicle:** Type (sedan, SUV, etc.), color, damage, commercial indicator
+- **Pet:** Type (cat/dog), breed
+- **Person:** Clothing, action, carrying items, suspicious attire warning, service uniform indicator
+- **License Plate:** OCR text with confidence
+- **Weather:** Weather condition
+- **Image Quality:** Quality score and detected issues
+
+**Props:**
+
+```typescript
+interface EnrichmentPanelProps {
+  /** Enrichment data to display */
+  enrichment_data?: EnrichmentData | null;
+  /** Additional CSS classes */
+  className?: string;
+}
+```
+
+**EnrichmentData Interface (from types/enrichment.ts):**
+
+```typescript
+interface EnrichmentData {
+  vehicle?: VehicleEnrichment;
+  pet?: PetEnrichment;
+  person?: PersonEnrichment;
+  license_plate?: LicensePlateEnrichment;
+  weather?: WeatherEnrichment;
+  image_quality?: ImageQualityEnrichment;
 }
 ```
 

--- a/frontend/src/components/events/EnrichmentPanel.test.tsx
+++ b/frontend/src/components/events/EnrichmentPanel.test.tsx
@@ -1,0 +1,489 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import EnrichmentPanel from './EnrichmentPanel';
+
+import type { EnrichmentData } from '../../types/enrichment';
+
+/**
+ * Helper function to expand an accordion section by clicking its header
+ */
+async function expandAccordion(headerText: string) {
+  const user = userEvent.setup();
+  const header = screen.getByText(headerText);
+  const button = header.closest('button');
+  if (button) {
+    await user.click(button);
+  }
+}
+
+describe('EnrichmentPanel', () => {
+  describe('rendering with no enrichment data', () => {
+    it('renders nothing when enrichment_data is undefined', () => {
+      const { container } = render(<EnrichmentPanel enrichment_data={undefined} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when enrichment_data is null', () => {
+      const { container } = render(<EnrichmentPanel enrichment_data={null as unknown as EnrichmentData} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when enrichment_data is an empty object', () => {
+      const { container } = render(<EnrichmentPanel enrichment_data={{}} />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('vehicle enrichment', () => {
+    const vehicleEnrichment: EnrichmentData = {
+      vehicle: {
+        type: 'sedan',
+        color: 'blue',
+        confidence: 0.92,
+      },
+    };
+
+    it('renders vehicle section when vehicle data exists', () => {
+      render(<EnrichmentPanel enrichment_data={vehicleEnrichment} />);
+      expect(screen.getByText('Vehicle')).toBeInTheDocument();
+    });
+
+    it('displays vehicle type', async () => {
+      render(<EnrichmentPanel enrichment_data={vehicleEnrichment} />);
+      await expandAccordion('Vehicle');
+      expect(screen.getByText('sedan')).toBeInTheDocument();
+    });
+
+    it('displays vehicle color', async () => {
+      render(<EnrichmentPanel enrichment_data={vehicleEnrichment} />);
+      await expandAccordion('Vehicle');
+      expect(screen.getByText('blue')).toBeInTheDocument();
+    });
+
+    it('displays confidence badge for vehicle', () => {
+      render(<EnrichmentPanel enrichment_data={vehicleEnrichment} />);
+      expect(screen.getByText('92%')).toBeInTheDocument();
+    });
+
+    it('displays damage when present', async () => {
+      const vehicleWithDamage: EnrichmentData = {
+        vehicle: {
+          type: 'SUV',
+          color: 'red',
+          damage: ['dents', 'scratches'],
+          confidence: 0.88,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={vehicleWithDamage} />);
+      await expandAccordion('Vehicle');
+      expect(screen.getByText(/dents/)).toBeInTheDocument();
+      expect(screen.getByText(/scratches/)).toBeInTheDocument();
+    });
+
+    it('displays commercial indicator when true', async () => {
+      const commercialVehicle: EnrichmentData = {
+        vehicle: {
+          type: 'van',
+          color: 'white',
+          commercial: true,
+          confidence: 0.95,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={commercialVehicle} />);
+      await expandAccordion('Vehicle');
+      expect(screen.getByText(/Commercial/)).toBeInTheDocument();
+    });
+
+    it('does not display commercial indicator when false', () => {
+      const personalVehicle: EnrichmentData = {
+        vehicle: {
+          type: 'sedan',
+          color: 'black',
+          commercial: false,
+          confidence: 0.90,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={personalVehicle} />);
+      expect(screen.queryByText(/Commercial/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('pet enrichment', () => {
+    const petEnrichment: EnrichmentData = {
+      pet: {
+        type: 'dog',
+        breed: 'Golden Retriever',
+        confidence: 0.95,
+      },
+    };
+
+    it('renders pet section when pet data exists', () => {
+      render(<EnrichmentPanel enrichment_data={petEnrichment} />);
+      expect(screen.getByText('Pet')).toBeInTheDocument();
+    });
+
+    it('displays pet type', async () => {
+      render(<EnrichmentPanel enrichment_data={petEnrichment} />);
+      await expandAccordion('Pet');
+      expect(screen.getByText('dog')).toBeInTheDocument();
+    });
+
+    it('displays breed when present', async () => {
+      render(<EnrichmentPanel enrichment_data={petEnrichment} />);
+      await expandAccordion('Pet');
+      expect(screen.getByText('Golden Retriever')).toBeInTheDocument();
+    });
+
+    it('displays confidence badge for pet', () => {
+      render(<EnrichmentPanel enrichment_data={petEnrichment} />);
+      expect(screen.getByText('95%')).toBeInTheDocument();
+    });
+
+    it('handles pet without breed', async () => {
+      const petWithoutBreed: EnrichmentData = {
+        pet: {
+          type: 'cat',
+          confidence: 0.87,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={petWithoutBreed} />);
+      await expandAccordion('Pet');
+      expect(screen.getByText('cat')).toBeInTheDocument();
+      expect(screen.getByText('87%')).toBeInTheDocument();
+    });
+  });
+
+  describe('person enrichment', () => {
+    const personEnrichment: EnrichmentData = {
+      person: {
+        clothing: 'dark jacket, jeans',
+        action: 'walking',
+        carrying: 'backpack',
+        confidence: 0.91,
+      },
+    };
+
+    it('renders person section when person data exists', () => {
+      render(<EnrichmentPanel enrichment_data={personEnrichment} />);
+      expect(screen.getByText('Person')).toBeInTheDocument();
+    });
+
+    it('displays clothing description', async () => {
+      render(<EnrichmentPanel enrichment_data={personEnrichment} />);
+      await expandAccordion('Person');
+      expect(screen.getByText('dark jacket, jeans')).toBeInTheDocument();
+    });
+
+    it('displays action', async () => {
+      render(<EnrichmentPanel enrichment_data={personEnrichment} />);
+      await expandAccordion('Person');
+      expect(screen.getByText('walking')).toBeInTheDocument();
+    });
+
+    it('displays carrying items', async () => {
+      render(<EnrichmentPanel enrichment_data={personEnrichment} />);
+      await expandAccordion('Person');
+      expect(screen.getByText('backpack')).toBeInTheDocument();
+    });
+
+    it('displays suspicious attire warning when true', async () => {
+      const suspiciousPerson: EnrichmentData = {
+        person: {
+          suspicious_attire: true,
+          confidence: 0.85,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={suspiciousPerson} />);
+      await expandAccordion('Person');
+      expect(screen.getByText(/Suspicious Attire/)).toBeInTheDocument();
+    });
+
+    it('displays service uniform indicator when true', async () => {
+      const serviceWorker: EnrichmentData = {
+        person: {
+          service_uniform: true,
+          confidence: 0.93,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={serviceWorker} />);
+      await expandAccordion('Person');
+      expect(screen.getByText(/Service Uniform/)).toBeInTheDocument();
+    });
+
+    it('displays confidence badge for person', () => {
+      render(<EnrichmentPanel enrichment_data={personEnrichment} />);
+      expect(screen.getByText('91%')).toBeInTheDocument();
+    });
+  });
+
+  describe('license plate enrichment', () => {
+    const licensePlateEnrichment: EnrichmentData = {
+      license_plate: {
+        text: 'ABC-1234',
+        confidence: 0.98,
+      },
+    };
+
+    it('renders license plate section when data exists', () => {
+      render(<EnrichmentPanel enrichment_data={licensePlateEnrichment} />);
+      expect(screen.getByText('License Plate')).toBeInTheDocument();
+    });
+
+    it('displays license plate text', async () => {
+      render(<EnrichmentPanel enrichment_data={licensePlateEnrichment} />);
+      await expandAccordion('License Plate');
+      expect(screen.getByText('ABC-1234')).toBeInTheDocument();
+    });
+
+    it('displays confidence badge for license plate', () => {
+      render(<EnrichmentPanel enrichment_data={licensePlateEnrichment} />);
+      expect(screen.getByText('98%')).toBeInTheDocument();
+    });
+  });
+
+  describe('weather enrichment', () => {
+    const weatherEnrichment: EnrichmentData = {
+      weather: {
+        condition: 'rain',
+        confidence: 0.89,
+      },
+    };
+
+    it('renders weather section when data exists', () => {
+      render(<EnrichmentPanel enrichment_data={weatherEnrichment} />);
+      expect(screen.getByText('Weather')).toBeInTheDocument();
+    });
+
+    it('displays weather condition', async () => {
+      render(<EnrichmentPanel enrichment_data={weatherEnrichment} />);
+      await expandAccordion('Weather');
+      expect(screen.getByText('rain')).toBeInTheDocument();
+    });
+
+    it('displays confidence badge for weather', () => {
+      render(<EnrichmentPanel enrichment_data={weatherEnrichment} />);
+      expect(screen.getByText('89%')).toBeInTheDocument();
+    });
+  });
+
+  describe('image quality enrichment', () => {
+    const imageQualityEnrichment: EnrichmentData = {
+      image_quality: {
+        score: 0.75,
+        issues: ['blur', 'low_light'],
+      },
+    };
+
+    it('renders image quality section when data exists', () => {
+      render(<EnrichmentPanel enrichment_data={imageQualityEnrichment} />);
+      expect(screen.getByText('Image Quality')).toBeInTheDocument();
+    });
+
+    it('displays quality score as percentage', () => {
+      render(<EnrichmentPanel enrichment_data={imageQualityEnrichment} />);
+      expect(screen.getByText('75%')).toBeInTheDocument();
+    });
+
+    it('displays quality issues', async () => {
+      render(<EnrichmentPanel enrichment_data={imageQualityEnrichment} />);
+      await expandAccordion('Image Quality');
+      expect(screen.getByText(/blur/)).toBeInTheDocument();
+      expect(screen.getByText(/low_light/)).toBeInTheDocument();
+    });
+
+    it('handles empty issues array', () => {
+      const perfectQuality: EnrichmentData = {
+        image_quality: {
+          score: 0.98,
+          issues: [],
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={perfectQuality} />);
+      expect(screen.getByText('98%')).toBeInTheDocument();
+    });
+  });
+
+  describe('confidence badge colors', () => {
+    it('displays green badge for high confidence (>0.9)', () => {
+      const highConfidence: EnrichmentData = {
+        vehicle: {
+          type: 'sedan',
+          color: 'blue',
+          confidence: 0.95,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={highConfidence} />);
+      const badge = screen.getByText('95%');
+      expect(badge).toHaveClass('bg-green-500/20');
+    });
+
+    it('displays yellow badge for medium confidence (0.7-0.9)', () => {
+      const mediumConfidence: EnrichmentData = {
+        vehicle: {
+          type: 'sedan',
+          color: 'blue',
+          confidence: 0.75,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={mediumConfidence} />);
+      const badge = screen.getByText('75%');
+      expect(badge).toHaveClass('bg-yellow-500/20');
+    });
+
+    it('displays red badge for low confidence (<0.7)', () => {
+      const lowConfidence: EnrichmentData = {
+        vehicle: {
+          type: 'sedan',
+          color: 'blue',
+          confidence: 0.55,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={lowConfidence} />);
+      const badge = screen.getByText('55%');
+      expect(badge).toHaveClass('bg-red-500/20');
+    });
+  });
+
+  describe('multiple enrichment types', () => {
+    const multipleEnrichments: EnrichmentData = {
+      vehicle: {
+        type: 'pickup',
+        color: 'silver',
+        confidence: 0.92,
+      },
+      license_plate: {
+        text: 'XYZ-9876',
+        confidence: 0.96,
+      },
+      weather: {
+        condition: 'clear',
+        confidence: 0.99,
+      },
+    };
+
+    it('renders all enrichment sections that have data', () => {
+      render(<EnrichmentPanel enrichment_data={multipleEnrichments} />);
+      expect(screen.getByText('Vehicle')).toBeInTheDocument();
+      expect(screen.getByText('License Plate')).toBeInTheDocument();
+      expect(screen.getByText('Weather')).toBeInTheDocument();
+    });
+
+    it('does not render sections without data', () => {
+      render(<EnrichmentPanel enrichment_data={multipleEnrichments} />);
+      expect(screen.queryByText('Pet')).not.toBeInTheDocument();
+      expect(screen.queryByText('Person')).not.toBeInTheDocument();
+      expect(screen.queryByText('Image Quality')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('accordion behavior', () => {
+    const enrichmentData: EnrichmentData = {
+      vehicle: {
+        type: 'SUV',
+        color: 'black',
+        confidence: 0.91,
+      },
+      pet: {
+        type: 'dog',
+        breed: 'Labrador',
+        confidence: 0.88,
+      },
+    };
+
+    it('can expand vehicle accordion section', async () => {
+      const user = userEvent.setup();
+      render(<EnrichmentPanel enrichment_data={enrichmentData} />);
+
+      const vehicleHeader = screen.getByText('Vehicle');
+      await user.click(vehicleHeader);
+
+      // After click, details should be visible
+      expect(screen.getByText('SUV')).toBeInTheDocument();
+    });
+
+    it('can expand pet accordion section', async () => {
+      const user = userEvent.setup();
+      render(<EnrichmentPanel enrichment_data={enrichmentData} />);
+
+      const petHeader = screen.getByText('Pet');
+      await user.click(petHeader);
+
+      // After click, details should be visible
+      expect(screen.getByText('Labrador')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    const enrichmentData: EnrichmentData = {
+      vehicle: {
+        type: 'sedan',
+        color: 'red',
+        confidence: 0.90,
+      },
+    };
+
+    it('has accessible panel structure', () => {
+      render(<EnrichmentPanel enrichment_data={enrichmentData} />);
+      expect(screen.getByTestId('enrichment-panel')).toBeInTheDocument();
+    });
+
+    it('has semantic section headers', () => {
+      render(<EnrichmentPanel enrichment_data={enrichmentData} />);
+      expect(screen.getByText('Vehicle')).toBeInTheDocument();
+    });
+  });
+
+  describe('className prop', () => {
+    it('applies custom className to container', () => {
+      const enrichmentData: EnrichmentData = {
+        weather: {
+          condition: 'sunny',
+          confidence: 0.95,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={enrichmentData} className="custom-class" />);
+      const panel = screen.getByTestId('enrichment-panel');
+      expect(panel).toHaveClass('custom-class');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles confidence at exact boundary values', () => {
+      const exactBoundary: EnrichmentData = {
+        vehicle: {
+          type: 'sedan',
+          color: 'white',
+          confidence: 0.9, // Exactly at boundary
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={exactBoundary} />);
+      expect(screen.getByText('90%')).toBeInTheDocument();
+    });
+
+    it('handles very long text values gracefully', async () => {
+      const longText: EnrichmentData = {
+        person: {
+          clothing: 'Very long description of clothing items including dark blue jacket with multiple pockets, light gray hoodie underneath, faded blue jeans',
+          confidence: 0.85,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={longText} />);
+      await expandAccordion('Person');
+      expect(screen.getByText(/Very long description/)).toBeInTheDocument();
+    });
+
+    it('handles special characters in license plate', async () => {
+      const specialChars: EnrichmentData = {
+        license_plate: {
+          text: 'ABC-1234 (CA)',
+          confidence: 0.92,
+        },
+      };
+      render(<EnrichmentPanel enrichment_data={specialChars} />);
+      await expandAccordion('License Plate');
+      expect(screen.getByText('ABC-1234 (CA)')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/events/EnrichmentPanel.tsx
+++ b/frontend/src/components/events/EnrichmentPanel.tsx
@@ -1,0 +1,345 @@
+/**
+ * EnrichmentPanel - Displays AI enrichment data for detections
+ *
+ * Shows enrichment data in collapsible accordion sections, including:
+ * - Vehicle classification (type, color, damage, commercial status)
+ * - Pet identification (type, breed)
+ * - Person attributes (clothing, action, carrying, suspicious/service indicators)
+ * - License plate OCR results
+ * - Weather conditions
+ * - Image quality assessment
+ */
+
+import { Accordion, AccordionHeader, AccordionBody, AccordionList } from '@tremor/react';
+import { clsx } from 'clsx';
+import {
+  Car,
+  Dog,
+  User,
+  CreditCard,
+  Cloud,
+  ImageIcon,
+  AlertTriangle,
+  Briefcase,
+  Package,
+} from 'lucide-react';
+
+import {
+  formatConfidencePercent,
+  getConfidenceBgColorClass,
+  getConfidenceBorderColorClass,
+  getConfidenceLevel,
+  getConfidenceTextColorClass,
+} from '../../utils/confidence';
+
+import type { EnrichmentData } from '../../types/enrichment';
+import type { ReactElement } from 'react';
+
+export interface EnrichmentPanelProps {
+  /** Enrichment data to display */
+  enrichment_data?: EnrichmentData | null;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Confidence badge component for consistent confidence display
+ */
+function ConfidenceBadge({ confidence }: { confidence: number }) {
+  const level = getConfidenceLevel(confidence);
+  const percent = formatConfidencePercent(confidence);
+
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium',
+        getConfidenceBgColorClass(level),
+        getConfidenceBorderColorClass(level),
+        getConfidenceTextColorClass(level)
+      )}
+    >
+      {percent}
+    </span>
+  );
+}
+
+/**
+ * Detail row component for consistent key-value display
+ */
+function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-2 py-1">
+      <span className="text-sm text-gray-400">{label}</span>
+      <span className="text-sm text-gray-200 text-right">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Badge indicator for boolean flags
+ */
+function FlagBadge({ label, variant = 'default' }: { label: string; variant?: 'warning' | 'info' | 'default' }) {
+  const variantClasses = {
+    warning: 'bg-yellow-500/20 border-yellow-500/40 text-yellow-400',
+    info: 'bg-blue-500/20 border-blue-500/40 text-blue-400',
+    default: 'bg-gray-500/20 border-gray-500/40 text-gray-400',
+  };
+
+  return (
+    <span className={clsx('inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium', variantClasses[variant])}>
+      {variant === 'warning' && <AlertTriangle className="h-3 w-3" />}
+      {variant === 'info' && <Briefcase className="h-3 w-3" />}
+      {label}
+    </span>
+  );
+}
+
+/**
+ * Check if enrichment data has any actual content
+ */
+function hasEnrichmentContent(data?: EnrichmentData | null): boolean {
+  if (!data) return false;
+  return !!(
+    data.vehicle ||
+    data.pet ||
+    data.person ||
+    data.license_plate ||
+    data.weather ||
+    data.image_quality
+  );
+}
+
+/**
+ * EnrichmentPanel - Main component
+ */
+export default function EnrichmentPanel({
+  enrichment_data,
+  className,
+}: EnrichmentPanelProps) {
+  // Don't render anything if there's no enrichment data
+  if (!hasEnrichmentContent(enrichment_data)) {
+    return null;
+  }
+
+  // Build array of accordion sections that have data
+  const accordionSections: ReactElement[] = [];
+
+  // Vehicle Section
+  if (enrichment_data?.vehicle) {
+    accordionSections.push(
+      <Accordion key="vehicle" data-testid="enrichment-vehicle">
+        <AccordionHeader className="px-4 py-3 text-white hover:bg-gray-800/50">
+          <div className="flex w-full items-center justify-between pr-2">
+            <div className="flex items-center gap-2">
+              <Car className="h-4 w-4 text-[#76B900]" />
+              <span className="font-medium">Vehicle</span>
+            </div>
+            <ConfidenceBadge confidence={enrichment_data.vehicle.confidence} />
+          </div>
+        </AccordionHeader>
+        <AccordionBody className="bg-black/20 px-4 py-3">
+          <div className="space-y-1">
+            <DetailRow label="Type" value={enrichment_data.vehicle.type} />
+            <DetailRow label="Color" value={enrichment_data.vehicle.color} />
+            {enrichment_data.vehicle.damage && enrichment_data.vehicle.damage.length > 0 && (
+              <DetailRow
+                label="Damage"
+                value={
+                  <div className="flex flex-wrap gap-1 justify-end">
+                    {enrichment_data.vehicle.damage.map((d, i) => (
+                      <span
+                        key={i}
+                        className="rounded bg-red-500/20 px-1.5 py-0.5 text-xs text-red-400"
+                      >
+                        {d}
+                      </span>
+                    ))}
+                  </div>
+                }
+              />
+            )}
+            {enrichment_data.vehicle.commercial && (
+              <div className="pt-2">
+                <FlagBadge label="Commercial Vehicle" variant="info" />
+              </div>
+            )}
+          </div>
+        </AccordionBody>
+      </Accordion>
+    );
+  }
+
+  // Pet Section
+  if (enrichment_data?.pet) {
+    accordionSections.push(
+      <Accordion key="pet" data-testid="enrichment-pet">
+        <AccordionHeader className="px-4 py-3 text-white hover:bg-gray-800/50">
+          <div className="flex w-full items-center justify-between pr-2">
+            <div className="flex items-center gap-2">
+              <Dog className="h-4 w-4 text-[#76B900]" />
+              <span className="font-medium">Pet</span>
+            </div>
+            <ConfidenceBadge confidence={enrichment_data.pet.confidence} />
+          </div>
+        </AccordionHeader>
+        <AccordionBody className="bg-black/20 px-4 py-3">
+          <div className="space-y-1">
+            <DetailRow label="Type" value={enrichment_data.pet.type} />
+            {enrichment_data.pet.breed && (
+              <DetailRow label="Breed" value={enrichment_data.pet.breed} />
+            )}
+          </div>
+        </AccordionBody>
+      </Accordion>
+    );
+  }
+
+  // Person Section
+  if (enrichment_data?.person) {
+    accordionSections.push(
+      <Accordion key="person" data-testid="enrichment-person">
+        <AccordionHeader className="px-4 py-3 text-white hover:bg-gray-800/50">
+          <div className="flex w-full items-center justify-between pr-2">
+            <div className="flex items-center gap-2">
+              <User className="h-4 w-4 text-[#76B900]" />
+              <span className="font-medium">Person</span>
+            </div>
+            <ConfidenceBadge confidence={enrichment_data.person.confidence} />
+          </div>
+        </AccordionHeader>
+        <AccordionBody className="bg-black/20 px-4 py-3">
+          <div className="space-y-1">
+            {enrichment_data.person.clothing && (
+              <DetailRow label="Clothing" value={enrichment_data.person.clothing} />
+            )}
+            {enrichment_data.person.action && (
+              <DetailRow label="Action" value={enrichment_data.person.action} />
+            )}
+            {enrichment_data.person.carrying && (
+              <DetailRow
+                label="Carrying"
+                value={
+                  <span className="flex items-center gap-1">
+                    <Package className="h-3 w-3" />
+                    {enrichment_data.person.carrying}
+                  </span>
+                }
+              />
+            )}
+            <div className="flex flex-wrap gap-2 pt-2">
+              {enrichment_data.person.suspicious_attire && (
+                <FlagBadge label="Suspicious Attire" variant="warning" />
+              )}
+              {enrichment_data.person.service_uniform && (
+                <FlagBadge label="Service Uniform" variant="info" />
+              )}
+            </div>
+          </div>
+        </AccordionBody>
+      </Accordion>
+    );
+  }
+
+  // License Plate Section
+  if (enrichment_data?.license_plate) {
+    accordionSections.push(
+      <Accordion key="license_plate" data-testid="enrichment-license-plate">
+        <AccordionHeader className="px-4 py-3 text-white hover:bg-gray-800/50">
+          <div className="flex w-full items-center justify-between pr-2">
+            <div className="flex items-center gap-2">
+              <CreditCard className="h-4 w-4 text-[#76B900]" />
+              <span className="font-medium">License Plate</span>
+            </div>
+            <ConfidenceBadge confidence={enrichment_data.license_plate.confidence} />
+          </div>
+        </AccordionHeader>
+        <AccordionBody className="bg-black/20 px-4 py-3">
+          <div className="flex items-center justify-center py-2">
+            <span className="rounded bg-gray-900 px-4 py-2 font-mono text-lg text-white tracking-wider border border-gray-700">
+              {enrichment_data.license_plate.text}
+            </span>
+          </div>
+        </AccordionBody>
+      </Accordion>
+    );
+  }
+
+  // Weather Section
+  if (enrichment_data?.weather) {
+    accordionSections.push(
+      <Accordion key="weather" data-testid="enrichment-weather">
+        <AccordionHeader className="px-4 py-3 text-white hover:bg-gray-800/50">
+          <div className="flex w-full items-center justify-between pr-2">
+            <div className="flex items-center gap-2">
+              <Cloud className="h-4 w-4 text-[#76B900]" />
+              <span className="font-medium">Weather</span>
+            </div>
+            <ConfidenceBadge confidence={enrichment_data.weather.confidence} />
+          </div>
+        </AccordionHeader>
+        <AccordionBody className="bg-black/20 px-4 py-3">
+          <div className="space-y-1">
+            <DetailRow label="Condition" value={enrichment_data.weather.condition} />
+          </div>
+        </AccordionBody>
+      </Accordion>
+    );
+  }
+
+  // Image Quality Section
+  if (enrichment_data?.image_quality) {
+    accordionSections.push(
+      <Accordion key="image_quality" data-testid="enrichment-image-quality">
+        <AccordionHeader className="px-4 py-3 text-white hover:bg-gray-800/50">
+          <div className="flex w-full items-center justify-between pr-2">
+            <div className="flex items-center gap-2">
+              <ImageIcon className="h-4 w-4 text-[#76B900]" />
+              <span className="font-medium">Image Quality</span>
+            </div>
+            <ConfidenceBadge confidence={enrichment_data.image_quality.score} />
+          </div>
+        </AccordionHeader>
+        <AccordionBody className="bg-black/20 px-4 py-3">
+          <div className="space-y-2">
+            <DetailRow
+              label="Quality Score"
+              value={formatConfidencePercent(enrichment_data.image_quality.score)}
+            />
+            {enrichment_data.image_quality.issues.length > 0 && (
+              <DetailRow
+                label="Issues"
+                value={
+                  <div className="flex flex-wrap gap-1 justify-end">
+                    {enrichment_data.image_quality.issues.map((issue, i) => (
+                      <span
+                        key={i}
+                        className="rounded bg-yellow-500/20 px-1.5 py-0.5 text-xs text-yellow-400"
+                      >
+                        {issue}
+                      </span>
+                    ))}
+                  </div>
+                }
+              />
+            )}
+          </div>
+        </AccordionBody>
+      </Accordion>
+    );
+  }
+
+  return (
+    <div
+      data-testid="enrichment-panel"
+      className={clsx('rounded-lg border border-gray-800 bg-black/20', className)}
+    >
+      <h3 className="px-4 py-3 text-sm font-semibold uppercase tracking-wide text-gray-400 border-b border-gray-800">
+        AI Enrichment Analysis
+      </h3>
+
+      <AccordionList className="divide-y divide-gray-800">
+        {accordionSections}
+      </AccordionList>
+    </div>
+  );
+}

--- a/frontend/src/components/events/EventDetailModal.tsx
+++ b/frontend/src/components/events/EventDetailModal.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { Fragment, useEffect, useMemo, useState } from 'react';
 
+import EnrichmentPanel from './EnrichmentPanel';
 import ThumbnailStrip from './ThumbnailStrip';
 import {
   fetchEventDetections,
@@ -41,6 +42,7 @@ import DetectionImage from '../detection/DetectionImage';
 import VideoPlayer from '../video/VideoPlayer';
 
 import type { DetectionThumbnail } from './ThumbnailStrip';
+import type { EnrichmentData } from '../../types/enrichment';
 import type { Detection as ApiDetection } from '../../types/generated';
 import type { LightboxImage } from '../common/Lightbox';
 import type { BoundingBox } from '../detection/BoundingBoxOverlay';
@@ -49,6 +51,7 @@ export interface Detection {
   label: string;
   confidence: number;
   bbox?: { x: number; y: number; width: number; height: number };
+  enrichment_data?: EnrichmentData;
 }
 
 export interface Event {
@@ -677,6 +680,21 @@ export default function EventDetailModal({
                           );
                         })}
                       </div>
+                    </div>
+                  )}
+
+                  {/* AI Enrichment Analysis */}
+                  {event.detections.some((d) => d.enrichment_data) && (
+                    <div className="mb-6">
+                      {event.detections
+                        .filter((d) => d.enrichment_data)
+                        .map((detection, index) => (
+                          <EnrichmentPanel
+                            key={`enrichment-${index}`}
+                            enrichment_data={detection.enrichment_data}
+                            className="mb-3"
+                          />
+                        ))}
                     </div>
                   )}
 

--- a/frontend/src/components/events/index.ts
+++ b/frontend/src/components/events/index.ts
@@ -4,6 +4,7 @@ export { default as EventDetailModal } from './EventDetailModal';
 export { default as EventTimeline } from './EventTimeline';
 export { default as ExportPanel } from './ExportPanel';
 export { default as ThumbnailStrip } from './ThumbnailStrip';
+export { default as EnrichmentPanel } from './EnrichmentPanel';
 
 // Type exports
 export type { EventCardProps } from './EventCard';
@@ -11,3 +12,4 @@ export type { Event, Detection, EventDetailModalProps } from './EventDetailModal
 export type { EventTimelineProps } from './EventTimeline';
 export type { ExportPanelProps, ExportFormat } from './ExportPanel';
 export type { DetectionThumbnail, ThumbnailStripProps } from './ThumbnailStrip';
+export type { EnrichmentPanelProps } from './EnrichmentPanel';

--- a/frontend/src/types/enrichment.ts
+++ b/frontend/src/types/enrichment.ts
@@ -1,0 +1,105 @@
+/**
+ * Enrichment data types for AI-powered detection enrichment.
+ *
+ * These types represent the additional AI analysis data computed by the backend
+ * enrichment pipeline, including vehicle classification, pet identification,
+ * person attributes, license plates, weather conditions, and image quality.
+ *
+ * @see backend/services/enrichment_service.py
+ */
+
+/**
+ * Vehicle enrichment data from AI classification.
+ */
+export interface VehicleEnrichment {
+  /** Vehicle type classification */
+  type: string; // sedan, SUV, pickup, van, truck
+  /** Vehicle color */
+  color: string;
+  /** Detected damage types (if any) */
+  damage?: string[]; // cracks, dents, glass_shatter, lamp_broken, scratches, tire_flat
+  /** Whether the vehicle appears to be commercial */
+  commercial?: boolean;
+  /** Confidence score for the vehicle classification (0-1) */
+  confidence: number;
+}
+
+/**
+ * Pet enrichment data from AI identification.
+ */
+export interface PetEnrichment {
+  /** Pet type */
+  type: 'cat' | 'dog';
+  /** Detected breed (if identifiable) */
+  breed?: string;
+  /** Confidence score for the pet identification (0-1) */
+  confidence: number;
+}
+
+/**
+ * Person enrichment data from AI analysis.
+ */
+export interface PersonEnrichment {
+  /** Clothing description */
+  clothing?: string;
+  /** Detected action/pose */
+  action?: string; // walking, standing, crouching
+  /** Items being carried */
+  carrying?: string; // backpack, package
+  /** Whether attire appears suspicious (masks, hoods at night, etc.) */
+  suspicious_attire?: boolean;
+  /** Whether person appears to be wearing a service uniform */
+  service_uniform?: boolean;
+  /** Confidence score for the person analysis (0-1) */
+  confidence: number;
+}
+
+/**
+ * License plate enrichment data from OCR.
+ */
+export interface LicensePlateEnrichment {
+  /** Detected license plate text */
+  text: string;
+  /** Confidence score for the OCR result (0-1) */
+  confidence: number;
+}
+
+/**
+ * Weather enrichment data from image analysis.
+ */
+export interface WeatherEnrichment {
+  /** Detected weather condition (clear, rain, snow, fog, etc.) */
+  condition: string;
+  /** Confidence score for the weather detection (0-1) */
+  confidence: number;
+}
+
+/**
+ * Image quality enrichment data.
+ */
+export interface ImageQualityEnrichment {
+  /** Quality score (0-1, where 1 is perfect quality) */
+  score: number;
+  /** List of detected quality issues */
+  issues: string[]; // blur, low_light, overexposed, noise, etc.
+}
+
+/**
+ * Complete enrichment data for a detection.
+ * All fields are optional as each enrichment type is computed conditionally
+ * based on what is detected in the image.
+ */
+export interface EnrichmentData {
+  /** Vehicle classification and attributes */
+  vehicle?: VehicleEnrichment;
+  /** Pet identification */
+  pet?: PetEnrichment;
+  /** Person attributes and behavior */
+  person?: PersonEnrichment;
+  /** License plate OCR result */
+  license_plate?: LicensePlateEnrichment;
+  /** Weather condition detection */
+  weather?: WeatherEnrichment;
+  /** Image quality assessment */
+  image_quality?: ImageQualityEnrichment;
+}

--- a/frontend/src/types/generated/api.ts
+++ b/frontend/src/types/generated/api.ts
@@ -3881,6 +3881,20 @@ export interface components {
          *       "camera_id": "123e4567-e89b-12d3-a456-426614174000",
          *       "confidence": 0.95,
          *       "detected_at": "2025-12-23T12:00:00Z",
+         *       "enrichment_data": {
+         *         "person": {
+         *           "action": "walking",
+         *           "carrying": "backpack",
+         *           "clothing": "dark jacket",
+         *           "confidence": 0.95
+         *         },
+         *         "vehicle": {
+         *           "color": "blue",
+         *           "confidence": 0.92,
+         *           "damage": [],
+         *           "type": "sedan"
+         *         }
+         *       },
          *       "file_path": "/export/foscam/front_door/20251223_120000.jpg",
          *       "file_type": "image/jpeg",
          *       "id": 1,
@@ -3977,6 +3991,13 @@ export interface components {
              * @description Video resolution height
              */
             video_height?: number | null;
+            /**
+             * Enrichment Data
+             * @description AI enrichment data including vehicle classification, pet identification, person attributes, license plates, weather, and image quality scores
+             */
+            enrichment_data?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * EntityAppearance


### PR DESCRIPTION
## Summary

- Add full-stack support for displaying AI enrichment data in the Event Detail Modal
- Backend: JSONB column for enrichment storage with persistence during analysis
- Frontend: New EnrichmentPanel component with Tremor accordions

**Enrichment Types:**
- Vehicle classification (type, color, damage, commercial)
- Pet identification (type, breed)
- Person attributes (clothing, action, carrying, suspicious/service indicators)
- License plate OCR
- Weather conditions
- Image quality assessment

## Test plan

- [x] Backend unit tests (9 tests passing)
- [x] Backend integration tests (3 tests passing)
- [x] Frontend component tests (45 tests passing)
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)