### PR TITLE
feat: Wave 2 AI Performance page enhancements (NEM-1136, NEM-1135, NEM-1129)

### DIFF
--- a/backend/tests/unit/api/routes/test_system_models.py
+++ b/backend/tests/unit/api/routes/test_system_models.py
@@ -312,3 +312,360 @@ class TestVRAMStats:
 
         assert data["vram_used_mb"] == 0
         assert data["vram_available_mb"] == data["vram_budget_mb"]
+
+
+class TestModelZooStatusEndpoint:
+    """Tests for GET /api/system/model-zoo/status endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_model_zoo_status_returns_all_models(self) -> None:
+        """Test that GET /api/system/model-zoo/status returns status for all models."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get("/api/system/model-zoo/status")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify top-level response structure
+        assert "models" in data
+        assert "total_models" in data
+        assert "loaded_count" in data
+        assert "disabled_count" in data
+        assert "vram_budget_mb" in data
+        assert "vram_used_mb" in data
+        assert "timestamp" in data
+
+        # Should have multiple models
+        assert len(data["models"]) > 0
+        assert data["total_models"] == len(data["models"])
+
+    @pytest.mark.asyncio
+    async def test_model_zoo_status_item_structure(self) -> None:
+        """Test that each model status item has required fields."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get("/api/system/model-zoo/status")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Check first model has required fields
+        model = data["models"][0]
+        required_fields = [
+            "name",
+            "display_name",
+            "category",
+            "status",
+            "vram_mb",
+            "last_used_at",
+            "enabled",
+        ]
+        for field in required_fields:
+            assert field in model, f"Missing required field: {field}"
+
+    @pytest.mark.asyncio
+    async def test_model_zoo_status_shows_loaded_models(self) -> None:
+        """Test that loaded models show 'loaded' status in compact view."""
+        # Mock ModelManager with a loaded model
+        mock_manager = MagicMock()
+        mock_manager.loaded_models = ["yolo11-license-plate"]
+        mock_manager.total_loaded_vram = 300
+        mock_manager._load_counts = {"yolo11-license-plate": 1}
+
+        with patch(
+            "backend.api.routes.system.get_model_manager",
+            return_value=mock_manager,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get("/api/system/model-zoo/status")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Find the loaded model
+        loaded_model = None
+        for model in data["models"]:
+            if model["name"] == "yolo11-license-plate":
+                loaded_model = model
+                break
+
+        assert loaded_model is not None
+        assert loaded_model["status"] == "loaded"
+        assert data["loaded_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_model_zoo_status_shows_disabled_models(self) -> None:
+        """Test that disabled models show 'disabled' status."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get("/api/system/model-zoo/status")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Find a disabled model (yolo26-general is disabled by default)
+        disabled_model = None
+        for model in data["models"]:
+            if model["name"] == "yolo26-general":
+                disabled_model = model
+                break
+
+        assert disabled_model is not None
+        assert disabled_model["status"] == "disabled"
+        assert disabled_model["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_model_zoo_status_models_sorted_correctly(self) -> None:
+        """Test that models are sorted with enabled first, then disabled."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get("/api/system/model-zoo/status")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Check that all enabled models come before disabled models
+        found_disabled = False
+        for model in data["models"]:
+            if not model["enabled"]:
+                found_disabled = True
+            elif found_disabled:
+                # Found enabled model after disabled - wrong order
+                pytest.fail("Enabled models should appear before disabled models")
+
+
+class TestModelZooLatencyHistoryEndpoint:
+    """Tests for GET /api/system/model-zoo/latency/history endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_latency_history_requires_model_param(self) -> None:
+        """Test that model parameter is required."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get("/api/system/model-zoo/latency/history")
+
+        assert response.status_code == 422  # Validation error
+
+    @pytest.mark.asyncio
+    async def test_get_latency_history_for_valid_model(self) -> None:
+        """Test that valid model returns latency history."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get(
+                "/api/system/model-zoo/latency/history",
+                params={"model": "yolo11-license-plate"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify response structure
+        assert data["model_name"] == "yolo11-license-plate"
+        assert "display_name" in data
+        assert "snapshots" in data
+        assert "window_minutes" in data
+        assert "bucket_seconds" in data
+        assert "has_data" in data
+        assert "timestamp" in data
+
+    @pytest.mark.asyncio
+    async def test_get_latency_history_not_found_for_invalid_model(self) -> None:
+        """Test that invalid model returns 404."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get(
+                "/api/system/model-zoo/latency/history",
+                params={"model": "nonexistent-model"},
+            )
+
+        assert response.status_code == 404
+        data = response.json()
+        assert "not found" in data["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_get_latency_history_respects_since_param(self) -> None:
+        """Test that since parameter controls window size."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get(
+                "/api/system/model-zoo/latency/history",
+                params={"model": "yolo11-license-plate", "since": 30},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["window_minutes"] == 30
+
+    @pytest.mark.asyncio
+    async def test_get_latency_history_respects_bucket_seconds_param(self) -> None:
+        """Test that bucket_seconds parameter controls bucket size."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get(
+                "/api/system/model-zoo/latency/history",
+                params={"model": "yolo11-license-plate", "bucket_seconds": 120},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["bucket_seconds"] == 120
+
+    @pytest.mark.asyncio
+    async def test_get_latency_history_with_data(self) -> None:
+        """Test that latency history with data returns proper snapshots."""
+        from backend.core.metrics import ModelLatencyTracker
+
+        # Create a tracker with some data
+        mock_tracker = ModelLatencyTracker(max_samples=100)
+        mock_tracker.record_model_latency("yolo11-license-plate", 45.0)
+        mock_tracker.record_model_latency("yolo11-license-plate", 50.0)
+        mock_tracker.record_model_latency("yolo11-license-plate", 55.0)
+
+        with patch(
+            "backend.core.metrics.get_model_latency_tracker",
+            return_value=mock_tracker,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/api/system/model-zoo/latency/history",
+                    params={"model": "yolo11-license-plate"},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["has_data"] is True
+        assert len(data["snapshots"]) > 0
+
+        # Find a snapshot with data
+        snapshot_with_data = None
+        for snapshot in data["snapshots"]:
+            if snapshot["stats"] is not None:
+                snapshot_with_data = snapshot
+                break
+
+        assert snapshot_with_data is not None
+        stats = snapshot_with_data["stats"]
+        assert "avg_ms" in stats
+        assert "p50_ms" in stats
+        assert "p95_ms" in stats
+        assert "sample_count" in stats
+
+    @pytest.mark.asyncio
+    async def test_get_latency_history_no_data_shows_empty(self) -> None:
+        """Test that model with no data returns has_data=False."""
+        from backend.core.metrics import ModelLatencyTracker
+
+        # Create an empty tracker
+        mock_tracker = ModelLatencyTracker(max_samples=100)
+
+        with patch(
+            "backend.core.metrics.get_model_latency_tracker",
+            return_value=mock_tracker,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/api/system/model-zoo/latency/history",
+                    params={"model": "yolo11-license-plate"},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["has_data"] is False
+
+
+class TestModelLatencyTracker:
+    """Tests for ModelLatencyTracker class."""
+
+    def test_record_and_get_model_stats(self) -> None:
+        """Test recording latency and retrieving stats."""
+        from backend.core.metrics import ModelLatencyTracker
+
+        tracker = ModelLatencyTracker(max_samples=100)
+        tracker.record_model_latency("test-model", 100.0)
+        tracker.record_model_latency("test-model", 200.0)
+        tracker.record_model_latency("test-model", 300.0)
+
+        stats = tracker.get_model_stats("test-model", window_minutes=60)
+
+        assert stats["sample_count"] == 3
+        assert stats["avg_ms"] == 200.0
+        assert stats["p50_ms"] is not None
+        assert stats["p95_ms"] is not None
+
+    def test_get_stats_for_unknown_model(self) -> None:
+        """Test that unknown model returns empty stats."""
+        from backend.core.metrics import ModelLatencyTracker
+
+        tracker = ModelLatencyTracker(max_samples=100)
+        stats = tracker.get_model_stats("unknown-model", window_minutes=60)
+
+        assert stats["sample_count"] == 0
+        assert stats["avg_ms"] is None
+        assert stats["p50_ms"] is None
+        assert stats["p95_ms"] is None
+
+    def test_get_model_latency_history_buckets(self) -> None:
+        """Test that latency history returns bucketed data."""
+        from backend.core.metrics import ModelLatencyTracker
+
+        tracker = ModelLatencyTracker(max_samples=100)
+        tracker.record_model_latency("test-model", 50.0)
+
+        history = tracker.get_model_latency_history(
+            "test-model",
+            window_minutes=5,
+            bucket_seconds=60,
+        )
+
+        # Should have 5 buckets (5 minutes * 60 seconds / 60 seconds per bucket)
+        assert len(history) == 5
+
+        # Each bucket should have timestamp and stats (can be None)
+        for snapshot in history:
+            assert "timestamp" in snapshot
+            assert "stats" in snapshot
+
+    def test_circular_buffer_limits_samples(self) -> None:
+        """Test that circular buffer limits sample storage."""
+        from backend.core.metrics import ModelLatencyTracker
+
+        tracker = ModelLatencyTracker(max_samples=10)
+
+        # Record more than max samples
+        for i in range(20):
+            tracker.record_model_latency("test-model", float(i))
+
+        stats = tracker.get_model_stats("test-model", window_minutes=60)
+
+        # Should only have max_samples
+        assert stats["sample_count"] == 10

--- a/frontend/src/components/ai/AIAuditPage.test.tsx
+++ b/frontend/src/components/ai/AIAuditPage.test.tsx
@@ -49,16 +49,6 @@ vi.mock('../../services/api', () => ({
       audits_by_day: [],
     })
   ),
-  fetchModelLeaderboard: vi.fn(() =>
-    Promise.resolve({
-      entries: [
-        { model_name: 'rtdetr', contribution_rate: 1.0, quality_correlation: null, event_count: 1000 },
-        { model_name: 'florence', contribution_rate: 0.85, quality_correlation: null, event_count: 850 },
-        { model_name: 'image_quality', contribution_rate: 0.7, quality_correlation: null, event_count: 700 },
-      ],
-      period_days: 7,
-    })
-  ),
   fetchAuditRecommendations: vi.fn(() =>
     Promise.resolve({
       recommendations: [
@@ -127,20 +117,6 @@ describe('AIAuditPage', () => {
     renderWithRouter();
     await waitFor(() => {
       expect(screen.getByTestId('quality-score-trends')).toBeInTheDocument();
-    });
-  });
-
-  it('renders model contribution chart', async () => {
-    renderWithRouter();
-    await waitFor(() => {
-      expect(screen.getByTestId('model-contribution-chart')).toBeInTheDocument();
-    });
-  });
-
-  it('renders model leaderboard', async () => {
-    renderWithRouter();
-    await waitFor(() => {
-      expect(screen.getByTestId('model-leaderboard')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/ai/AIAuditPage.tsx
+++ b/frontend/src/components/ai/AIAuditPage.tsx
@@ -1,11 +1,11 @@
 /**
- * AIAuditPage - Dashboard for AI model contribution and quality metrics
+ * AIAuditPage - Dashboard for AI quality metrics and recommendations
  *
  * Displays aggregate statistics from the AI pipeline audit system including:
  * - Quality score metrics and trends
- * - Model contribution rates chart
- * - Model leaderboard with rankings
  * - Prompt improvement recommendations
+ *
+ * Note: Model contribution rates and leaderboard are now on the AI Performance page
  */
 
 import { Text, Callout, Select, SelectItem } from '@tremor/react';
@@ -13,19 +13,15 @@ import { ClipboardCheck, RefreshCw, AlertCircle, Calendar, Play } from 'lucide-r
 import { useEffect, useState, useCallback } from 'react';
 
 import BatchAuditModal from './BatchAuditModal';
-import ModelContributionChart from './ModelContributionChart';
-import ModelLeaderboard from './ModelLeaderboard';
 import QualityScoreTrends from './QualityScoreTrends';
 import RecommendationsPanel from './RecommendationsPanel';
 import {
   fetchAiAuditStats,
-  fetchModelLeaderboard,
   fetchAuditRecommendations,
 } from '../../services/api';
 
 import type {
   AiAuditStatsResponse,
-  AiAuditLeaderboardResponse,
   AiAuditRecommendationsResponse,
 } from '../../services/api';
 import type { BatchAuditResponse } from '../../services/auditApi';
@@ -36,7 +32,6 @@ import type { BatchAuditResponse } from '../../services/auditApi';
 export default function AIAuditPage() {
   // Data state
   const [stats, setStats] = useState<AiAuditStatsResponse | null>(null);
-  const [leaderboard, setLeaderboard] = useState<AiAuditLeaderboardResponse | null>(null);
   const [recommendations, setRecommendations] = useState<AiAuditRecommendationsResponse | null>(
     null
   );
@@ -59,14 +54,12 @@ export default function AIAuditPage() {
     setError(null);
 
     try {
-      const [statsData, leaderboardData, recommendationsData] = await Promise.all([
+      const [statsData, recommendationsData] = await Promise.all([
         fetchAiAuditStats({ days: periodDays }),
-        fetchModelLeaderboard({ days: periodDays }),
         fetchAuditRecommendations({ days: periodDays }),
       ]);
 
       setStats(statsData);
-      setLeaderboard(leaderboardData);
       setRecommendations(recommendationsData);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load AI audit data');
@@ -249,21 +242,7 @@ export default function AIAuditPage() {
               fullyEvaluatedEvents={stats.fully_evaluated_events}
             />
 
-            {/* Charts Row */}
-            <div className="grid gap-6 lg:grid-cols-2">
-              {/* Model Contribution Chart */}
-              <ModelContributionChart contributionRates={stats.model_contribution_rates} />
-
-              {/* Model Leaderboard */}
-              {leaderboard && (
-                <ModelLeaderboard
-                  entries={leaderboard.entries}
-                  periodDays={leaderboard.period_days}
-                />
-              )}
-            </div>
-
-            {/* Recommendations Panel */}
+            {/* Recommendations Panel (full width) */}
             {recommendations && (
               <RecommendationsPanel
                 recommendations={recommendations.recommendations}

--- a/frontend/src/components/ai/AIPerformancePage.test.tsx
+++ b/frontend/src/components/ai/AIPerformancePage.test.tsx
@@ -35,6 +35,31 @@ vi.mock('../../services/api', () => ({
       events_by_camera: [],
     })
   ),
+  fetchAiAuditStats: vi.fn(() =>
+    Promise.resolve({
+      total_events: 1000,
+      audited_events: 950,
+      fully_evaluated_events: 800,
+      avg_quality_score: 4.2,
+      avg_consistency_rate: 4.0,
+      avg_enrichment_utilization: 0.75,
+      model_contribution_rates: {
+        rtdetr: 1.0,
+        florence: 0.85,
+        clip: 0.6,
+      },
+      audits_by_day: [],
+    })
+  ),
+  fetchModelLeaderboard: vi.fn(() =>
+    Promise.resolve({
+      entries: [
+        { model_name: 'rtdetr', contribution_rate: 1.0, quality_correlation: null, event_count: 1000 },
+        { model_name: 'florence', contribution_rate: 0.85, quality_correlation: null, event_count: 850 },
+      ],
+      period_days: 7,
+    })
+  ),
 }));
 
 // Default mock data for healthy state
@@ -157,6 +182,34 @@ describe('AIPerformancePage', () => {
       renderWithRouter();
       await waitFor(() => {
         expect(screen.getByTestId('insights-charts')).toBeInTheDocument();
+      });
+    });
+
+    it('renders Model Zoo Analytics section', async () => {
+      renderWithRouter();
+      await waitFor(() => {
+        expect(screen.getByTestId('model-zoo-analytics-section')).toBeInTheDocument();
+      });
+    });
+
+    it('renders Model Zoo Analytics title', async () => {
+      renderWithRouter();
+      await waitFor(() => {
+        expect(screen.getByText('Model Zoo Analytics')).toBeInTheDocument();
+      });
+    });
+
+    it('renders model contribution chart in Model Zoo Analytics', async () => {
+      renderWithRouter();
+      await waitFor(() => {
+        expect(screen.getByTestId('model-contribution-chart')).toBeInTheDocument();
+      });
+    });
+
+    it('renders model leaderboard in Model Zoo Analytics', async () => {
+      renderWithRouter();
+      await waitFor(() => {
+        expect(screen.getByTestId('model-leaderboard')).toBeInTheDocument();
       });
     });
 

--- a/frontend/src/components/ai/ModelZooSection.test.tsx
+++ b/frontend/src/components/ai/ModelZooSection.test.tsx
@@ -1,0 +1,369 @@
+/**
+ * Tests for ModelZooSection component
+ *
+ * Tests the Model Zoo status display with dropdown-controlled latency chart
+ * and compact status cards for all Model Zoo models.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, type Mock } from 'vitest';
+
+import ModelZooSection from './ModelZooSection';
+import * as api from '../../services/api';
+
+import type { ModelZooStatusResponse, ModelLatencyHistoryResponse } from '../../services/api';
+
+// Mock the API functions
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual<typeof api>('../../services/api');
+  return {
+    ...actual,
+    fetchModelZooCompactStatus: vi.fn(),
+    fetchModelZooLatencyHistory: vi.fn(),
+  };
+});
+
+// Sample test data
+const mockStatusResponse: ModelZooStatusResponse = {
+  models: [
+    {
+      name: 'yolo11-license-plate',
+      display_name: 'YOLO11 License Plate',
+      category: 'Detection',
+      status: 'unloaded',
+      vram_mb: 300,
+      last_used_at: null,
+      enabled: true,
+    },
+    {
+      name: 'yolo11-face',
+      display_name: 'YOLO11 Face',
+      category: 'Detection',
+      status: 'loaded',
+      vram_mb: 200,
+      last_used_at: '2026-01-04T10:00:00Z',
+      enabled: true,
+    },
+    {
+      name: 'violence-detection',
+      display_name: 'Violence Detection',
+      category: 'Classification',
+      status: 'unloaded',
+      vram_mb: 150,
+      last_used_at: null,
+      enabled: true,
+    },
+    {
+      name: 'yolo26-general',
+      display_name: 'YOLO26 General',
+      category: 'Detection',
+      status: 'disabled',
+      vram_mb: 400,
+      last_used_at: null,
+      enabled: false,
+    },
+  ],
+  total_models: 4,
+  loaded_count: 1,
+  disabled_count: 1,
+  vram_budget_mb: 1650,
+  vram_used_mb: 200,
+  timestamp: '2026-01-04T12:00:00Z',
+};
+
+const mockLatencyResponse: ModelLatencyHistoryResponse = {
+  model_name: 'yolo11-license-plate',
+  display_name: 'YOLO11 License Plate',
+  snapshots: [
+    {
+      timestamp: '2026-01-04T11:00:00Z',
+      stats: {
+        avg_ms: 45.0,
+        p50_ms: 42.0,
+        p95_ms: 68.0,
+        sample_count: 15,
+      },
+    },
+    {
+      timestamp: '2026-01-04T11:01:00Z',
+      stats: {
+        avg_ms: 48.0,
+        p50_ms: 45.0,
+        p95_ms: 72.0,
+        sample_count: 20,
+      },
+    },
+  ],
+  window_minutes: 60,
+  bucket_seconds: 60,
+  has_data: true,
+  timestamp: '2026-01-04T12:00:00Z',
+};
+
+const mockEmptyLatencyResponse: ModelLatencyHistoryResponse = {
+  model_name: 'yolo11-license-plate',
+  display_name: 'YOLO11 License Plate',
+  snapshots: [],
+  window_minutes: 60,
+  bucket_seconds: 60,
+  has_data: false,
+  timestamp: '2026-01-04T12:00:00Z',
+};
+
+describe('ModelZooSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (api.fetchModelZooCompactStatus as Mock).mockResolvedValue(mockStatusResponse);
+    (api.fetchModelZooLatencyHistory as Mock).mockResolvedValue(mockLatencyResponse);
+  });
+
+  describe('basic rendering', () => {
+    it('renders the main container with correct testid', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByTestId('model-zoo-section')).toBeInTheDocument();
+      });
+    });
+
+    it('renders summary card with Model Zoo title', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByTestId('model-zoo-summary')).toBeInTheDocument();
+        expect(screen.getByText('Model Zoo')).toBeInTheDocument();
+      });
+    });
+
+    it('applies custom className', async () => {
+      render(<ModelZooSection className="custom-class" />);
+      await waitFor(() => {
+        expect(screen.getByTestId('model-zoo-section')).toHaveClass('custom-class');
+      });
+    });
+  });
+
+  describe('summary statistics', () => {
+    it('displays loaded count', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByText('1 loaded')).toBeInTheDocument();
+      });
+    });
+
+    it('displays unloaded count', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        // 4 total - 1 loaded - 1 disabled = 2 unloaded
+        expect(screen.getByText('2 unloaded')).toBeInTheDocument();
+      });
+    });
+
+    it('displays disabled count', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByText('1 disabled')).toBeInTheDocument();
+      });
+    });
+
+    it('displays VRAM usage', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByText('200/1650MB VRAM')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('latency chart', () => {
+    it('renders latency chart card', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByTestId('model-zoo-latency-chart')).toBeInTheDocument();
+      });
+    });
+
+    it('displays chart title', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByText('Model Zoo Latency Over Time')).toBeInTheDocument();
+      });
+    });
+
+    it('renders model selector dropdown', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByTestId('model-select')).toBeInTheDocument();
+      });
+    });
+
+    it('fetches latency history on mount', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(api.fetchModelZooLatencyHistory).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('status cards', () => {
+    it('renders enabled models grid', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByTestId('enabled-models-grid')).toBeInTheDocument();
+      });
+    });
+
+    it('renders disabled models grid', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByTestId('disabled-models-grid')).toBeInTheDocument();
+      });
+    });
+
+    it('renders model cards with correct testid', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByTestId('model-card-yolo11-license-plate')).toBeInTheDocument();
+        expect(screen.getByTestId('model-card-yolo11-face')).toBeInTheDocument();
+        expect(screen.getByTestId('model-card-violence-detection')).toBeInTheDocument();
+        expect(screen.getByTestId('model-card-yolo26-general')).toBeInTheDocument();
+      });
+    });
+
+    it('displays model display names', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByText('YOLO11 License Plate')).toBeInTheDocument();
+        expect(screen.getByText('YOLO11 Face')).toBeInTheDocument();
+        expect(screen.getByText('Violence Detection')).toBeInTheDocument();
+        expect(screen.getByText('YOLO26 General')).toBeInTheDocument();
+      });
+    });
+
+    it('displays VRAM amounts on cards', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        expect(screen.getByText('300MB')).toBeInTheDocument();
+        expect(screen.getByText('200MB')).toBeInTheDocument();
+        expect(screen.getByText('150MB')).toBeInTheDocument();
+        expect(screen.getByText('400MB')).toBeInTheDocument();
+      });
+    });
+
+    it('displays category badges on cards', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        // Detection appears multiple times on cards
+        const detectionBadges = screen.getAllByText('Detection');
+        expect(detectionBadges.length).toBeGreaterThan(0);
+        expect(screen.getByText('Classification')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('status indicators', () => {
+    it('displays Loaded status for loaded models', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        // yolo11-face is loaded
+        const faceCard = screen.getByTestId('model-card-yolo11-face');
+        expect(faceCard).toHaveTextContent('Loaded');
+      });
+    });
+
+    it('displays Unloaded status for unloaded models', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        // yolo11-license-plate is unloaded
+        const lpCard = screen.getByTestId('model-card-yolo11-license-plate');
+        expect(lpCard).toHaveTextContent('Unloaded');
+      });
+    });
+
+    it('displays Disabled status for disabled models', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        // yolo26-general is disabled
+        const generalCard = screen.getByTestId('model-card-yolo26-general');
+        expect(generalCard).toHaveTextContent('Disabled');
+      });
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows loading message initially', () => {
+      // Make the fetch take time
+      (api.fetchModelZooCompactStatus as Mock).mockImplementation(
+        () => new Promise(() => {})
+      );
+
+      render(<ModelZooSection />);
+
+      expect(screen.getByText('Loading Model Zoo status...')).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('displays error message when fetch fails', async () => {
+      (api.fetchModelZooCompactStatus as Mock).mockRejectedValue(
+        new Error('Network error')
+      );
+
+      render(<ModelZooSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Error loading Model Zoo status/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('no data state', () => {
+    it('displays no data message when model has no latency data', async () => {
+      (api.fetchModelZooLatencyHistory as Mock).mockResolvedValue(mockEmptyLatencyResponse);
+
+      render(<ModelZooSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/No data available/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('last used time', () => {
+    it('displays formatted time ago for recently used models', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        // yolo11-face was last used at a specific time
+        // Since we can't easily control the current time, just check it shows something
+        const faceCard = screen.getByTestId('model-card-yolo11-face');
+        expect(faceCard).toBeInTheDocument();
+      });
+    });
+
+    it('displays Never for models that have not been used', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        // yolo11-license-plate has never been used
+        const lpCard = screen.getByTestId('model-card-yolo11-license-plate');
+        expect(lpCard).toHaveTextContent('Never');
+      });
+    });
+  });
+
+  describe('polling behavior', () => {
+    it('accepts custom polling interval', async () => {
+      render(<ModelZooSection pollingInterval={5000} />);
+      await waitFor(() => {
+        expect(screen.getByTestId('model-zoo-section')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('active/disabled model sections', () => {
+    it('separates enabled and disabled models into different sections', async () => {
+      render(<ModelZooSection />);
+      await waitFor(() => {
+        // Check section headers
+        expect(screen.getByText('Active Models')).toBeInTheDocument();
+        expect(screen.getByText('Disabled Models')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/components/ai/ModelZooSection.tsx
+++ b/frontend/src/components/ai/ModelZooSection.tsx
@@ -1,0 +1,472 @@
+/**
+ * ModelZooSection - Displays Model Zoo status cards and latency chart
+ *
+ * Shows a dropdown-controlled latency chart and compact status cards for all
+ * 18 Model Zoo models. Models are grouped by category in the dropdown with
+ * disabled models at the bottom (grayed out).
+ */
+
+import { Card, Title, Text, AreaChart, Select, SelectItem } from '@tremor/react';
+import { clsx } from 'clsx';
+import { TrendingUp, Boxes, Cpu, MemoryStick, Clock } from 'lucide-react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+
+import {
+  fetchModelZooCompactStatus,
+  fetchModelZooLatencyHistory,
+  type ModelZooStatusResponse,
+  type ModelLatencyHistoryResponse,
+  type ModelZooStatusItem,
+} from '../../services/api';
+
+// ============================================================================
+// Model Category Configuration
+// ============================================================================
+
+/**
+ * Model categories for dropdown grouping (order matters for display)
+ */
+const MODEL_CATEGORIES = [
+  'Detection',
+  'Classification',
+  'Segmentation',
+  'Pose',
+  'Depth',
+  'Embedding',
+  'OCR',
+  'Action Recognition',
+  'Disabled',
+] as const;
+
+/**
+ * Props for ModelZooSection component
+ */
+export interface ModelZooSectionProps {
+  /** Additional CSS classes */
+  className?: string;
+  /** Polling interval in ms (default 30000 = 30s) */
+  pollingInterval?: number;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Format milliseconds for display
+ */
+function formatMs(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined) return '-';
+  if (ms < 1) return '< 1ms';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60000).toFixed(1)}m`;
+}
+
+/**
+ * Format time ago for display
+ */
+function formatTimeAgo(timestamp: string | null): string {
+  if (!timestamp) return 'Never';
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${diffDays}d ago`;
+}
+
+/**
+ * Get status indicator styles
+ */
+function getStatusStyles(status: ModelZooStatusItem['status']): {
+  dotColor: string;
+  bgColor: string;
+  label: string;
+} {
+  switch (status) {
+    case 'loaded':
+      return {
+        dotColor: 'bg-green-500',
+        bgColor: 'bg-green-500/10',
+        label: 'Loaded',
+      };
+    case 'loading':
+      return {
+        dotColor: 'bg-blue-500 animate-pulse',
+        bgColor: 'bg-blue-500/10',
+        label: 'Loading',
+      };
+    case 'disabled':
+      return {
+        dotColor: 'bg-yellow-500',
+        bgColor: 'bg-yellow-500/10',
+        label: 'Disabled',
+      };
+    case 'error':
+      return {
+        dotColor: 'bg-red-500',
+        bgColor: 'bg-red-500/10',
+        label: 'Error',
+      };
+    default:
+      return {
+        dotColor: 'bg-gray-500',
+        bgColor: 'bg-gray-500/10',
+        label: 'Unloaded',
+      };
+  }
+}
+
+// ============================================================================
+// ModelStatusCard Component
+// ============================================================================
+
+interface ModelStatusCardProps {
+  model: ModelZooStatusItem;
+}
+
+function ModelStatusCard({ model }: ModelStatusCardProps) {
+  const styles = getStatusStyles(model.status);
+
+  return (
+    <div
+      className={clsx(
+        'rounded-lg border border-gray-700 p-3 transition-colors',
+        model.enabled ? 'bg-gray-800/50' : 'bg-gray-900/50 opacity-60'
+      )}
+      data-testid={`model-card-${model.name}`}
+    >
+      {/* Header: Name and Status */}
+      <div className="mb-2 flex items-center justify-between">
+        <Text className="truncate text-sm font-medium text-gray-200" title={model.display_name}>
+          {model.display_name}
+        </Text>
+        <div className="flex items-center gap-1.5">
+          <span className={clsx('h-2 w-2 rounded-full', styles.dotColor)} />
+          <Text className="text-xs text-gray-400">{styles.label}</Text>
+        </div>
+      </div>
+
+      {/* Stats Row */}
+      <div className="flex items-center justify-between text-xs text-gray-400">
+        {/* VRAM */}
+        <div className="flex items-center gap-1">
+          <MemoryStick className="h-3 w-3" />
+          <span>{model.vram_mb}MB</span>
+        </div>
+
+        {/* Last Used */}
+        <div className="flex items-center gap-1">
+          <Clock className="h-3 w-3" />
+          <span>{formatTimeAgo(model.last_used_at)}</span>
+        </div>
+      </div>
+
+      {/* Category Badge */}
+      <div className="mt-2">
+        <span className="inline-block rounded bg-gray-700/50 px-1.5 py-0.5 text-xs text-gray-400">
+          {model.category}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// ModelLatencyChart Component
+// ============================================================================
+
+interface ModelLatencyChartProps {
+  selectedModel: string;
+  onModelChange: (model: string) => void;
+  models: ModelZooStatusItem[];
+}
+
+function ModelLatencyChart({ selectedModel, onModelChange, models }: ModelLatencyChartProps) {
+  const [historyData, setHistoryData] = useState<ModelLatencyHistoryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchHistory = useCallback(async () => {
+    if (!selectedModel) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await fetchModelZooLatencyHistory(selectedModel, 60, 60);
+      setHistoryData(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch latency history');
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedModel]);
+
+  // Fetch history when model changes or on interval
+  useEffect(() => {
+    void fetchHistory();
+    const interval = setInterval(() => void fetchHistory(), 60000);
+    return () => clearInterval(interval);
+  }, [fetchHistory]);
+
+  // Create a flat list of models with category prefixes for dropdown
+  // Tremor Select doesn't support nested category headers in options
+  const sortedModels = useMemo(() => {
+    const enabled = models.filter((m) => m.enabled);
+    const disabled = models.filter((m) => !m.enabled);
+
+    // Sort enabled by category, then by name
+    enabled.sort((a, b) => {
+      const catIndexA = MODEL_CATEGORIES.indexOf(a.category as (typeof MODEL_CATEGORIES)[number]);
+      const catIndexB = MODEL_CATEGORIES.indexOf(b.category as (typeof MODEL_CATEGORIES)[number]);
+      if (catIndexA !== catIndexB) return catIndexA - catIndexB;
+      return a.display_name.localeCompare(b.display_name);
+    });
+
+    // Disabled models go at the end
+    disabled.sort((a, b) => a.display_name.localeCompare(b.display_name));
+
+    return [...enabled, ...disabled];
+  }, [models]);
+
+  // Transform data for chart
+  const chartData =
+    historyData?.snapshots.map((snapshot) => {
+      const time = new Date(snapshot.timestamp).toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      return {
+        time,
+        'Avg (ms)': snapshot.stats?.avg_ms ?? null,
+        'P50 (ms)': snapshot.stats?.p50_ms ?? null,
+        'P95 (ms)': snapshot.stats?.p95_ms ?? null,
+      };
+    }) ?? [];
+
+  const selectedModelData = models.find((m) => m.name === selectedModel);
+  const modelDisplayName = selectedModelData?.display_name ?? selectedModel;
+
+  return (
+    <Card
+      className="border-gray-800 bg-[#1A1A1A] shadow-lg"
+      data-testid="model-zoo-latency-chart"
+    >
+      <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <Title className="flex items-center gap-2 text-white">
+          <TrendingUp className="h-5 w-5 text-[#76B900]" />
+          Model Zoo Latency Over Time
+        </Title>
+        <Select
+          value={selectedModel}
+          onValueChange={onModelChange}
+          className="w-full sm:w-64"
+          data-testid="model-select"
+        >
+          {sortedModels.map((model) => (
+            <SelectItem
+              key={model.name}
+              value={model.name}
+              className={clsx(!model.enabled && 'text-gray-500')}
+            >
+              [{model.category}] {model.display_name}
+              {!model.enabled && ' (disabled)'}
+            </SelectItem>
+          ))}
+        </Select>
+      </div>
+
+      {loading && !historyData && (
+        <div className="flex h-48 items-center justify-center">
+          <Text className="text-gray-500">Loading latency history for {modelDisplayName}...</Text>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex h-48 items-center justify-center">
+          <Text className="text-red-400">Error: {error}</Text>
+        </div>
+      )}
+
+      {!loading && !error && !historyData?.has_data && (
+        <div className="flex h-48 flex-col items-center justify-center gap-2">
+          <Text className="text-gray-400">No data available for {modelDisplayName}</Text>
+          <Text className="text-xs text-gray-500">
+            This model has not been used recently or is disabled
+          </Text>
+        </div>
+      )}
+
+      {historyData?.has_data && chartData.length > 0 && (
+        <AreaChart
+          className="h-48"
+          data={chartData}
+          index="time"
+          categories={['Avg (ms)', 'P50 (ms)', 'P95 (ms)']}
+          colors={['emerald', 'blue', 'amber']}
+          valueFormatter={(value) => (value !== null ? formatMs(value) : '-')}
+          showLegend={true}
+          showGridLines={true}
+          curveType="monotone"
+          connectNulls={false}
+          data-testid="model-latency-area-chart"
+        />
+      )}
+
+      {historyData?.timestamp && (
+        <Text className="mt-2 text-xs text-gray-500">
+          Last updated: {new Date(historyData.timestamp).toLocaleTimeString()}
+        </Text>
+      )}
+    </Card>
+  );
+}
+
+// ============================================================================
+// ModelZooSection Main Component
+// ============================================================================
+
+/**
+ * ModelZooSection - Main component for Model Zoo status and latency visualization
+ */
+export default function ModelZooSection({ className, pollingInterval = 30000 }: ModelZooSectionProps) {
+  const [statusData, setStatusData] = useState<ModelZooStatusResponse | null>(null);
+  const [selectedModel, setSelectedModel] = useState<string>('yolo11-license-plate');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await fetchModelZooCompactStatus();
+      setStatusData(data);
+
+      // Set default selected model if not set
+      if (data.models.length > 0 && !data.models.find((m) => m.name === selectedModel)) {
+        const firstEnabled = data.models.find((m) => m.enabled);
+        if (firstEnabled) {
+          setSelectedModel(firstEnabled.name);
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch Model Zoo status');
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedModel]);
+
+  // Fetch status on mount and at interval
+  useEffect(() => {
+    void fetchStatus();
+    const interval = setInterval(() => void fetchStatus(), pollingInterval);
+    return () => clearInterval(interval);
+  }, [fetchStatus, pollingInterval]);
+
+  // Group models by enabled/disabled for cards display
+  const enabledModels = statusData?.models.filter((m) => m.enabled) ?? [];
+  const disabledModels = statusData?.models.filter((m) => !m.enabled) ?? [];
+
+  return (
+    <div className={clsx('space-y-4', className)} data-testid="model-zoo-section">
+      {/* Summary Header */}
+      <Card className="border-gray-800 bg-[#1A1A1A] shadow-lg" data-testid="model-zoo-summary">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex items-center gap-2">
+            <Boxes className="h-5 w-5 text-[#76B900]" />
+            <Title className="text-white">Model Zoo</Title>
+          </div>
+
+          {statusData && (
+            <div className="flex flex-wrap items-center gap-4 text-sm text-gray-400">
+              <div className="flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-green-500" />
+                <span>{statusData.loaded_count} loaded</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-gray-500" />
+                <span>
+                  {statusData.total_models - statusData.loaded_count - statusData.disabled_count}{' '}
+                  unloaded
+                </span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-yellow-500" />
+                <span>{statusData.disabled_count} disabled</span>
+              </div>
+              <div className="flex items-center gap-1.5 border-l border-gray-700 pl-4">
+                <Cpu className="h-4 w-4" />
+                <span>
+                  {statusData.vram_used_mb}/{statusData.vram_budget_mb}MB VRAM
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+      </Card>
+
+      {/* Loading State */}
+      {loading && !statusData && (
+        <div className="flex h-64 items-center justify-center">
+          <Text className="text-gray-500">Loading Model Zoo status...</Text>
+        </div>
+      )}
+
+      {/* Error State */}
+      {error && (
+        <Card className="border-red-800 bg-red-900/20">
+          <Text className="text-red-400">Error loading Model Zoo status: {error}</Text>
+        </Card>
+      )}
+
+      {/* Latency Chart with Dropdown */}
+      {statusData && statusData.models.length > 0 && (
+        <ModelLatencyChart
+          selectedModel={selectedModel}
+          onModelChange={setSelectedModel}
+          models={statusData.models}
+        />
+      )}
+
+      {/* Status Cards Grid */}
+      {statusData && (
+        <div className="space-y-4">
+          {/* Enabled Models */}
+          {enabledModels.length > 0 && (
+            <div>
+              <Text className="mb-2 text-sm font-medium text-gray-400">Active Models</Text>
+              <div
+                className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+                data-testid="enabled-models-grid"
+              >
+                {enabledModels.map((model) => (
+                  <ModelStatusCard key={model.name} model={model} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Disabled Models */}
+          {disabledModels.length > 0 && (
+            <div>
+              <Text className="mb-2 text-sm font-medium text-gray-500">Disabled Models</Text>
+              <div
+                className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+                data-testid="disabled-models-grid"
+              >
+                {disabledModels.map((model) => (
+                  <ModelStatusCard key={model.name} model={model} />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/events/EventTimeline.test.tsx
+++ b/frontend/src/components/events/EventTimeline.test.tsx
@@ -1763,6 +1763,61 @@ describe('EventTimeline', () => {
     });
   });
 
+  describe('URL Parameter Filtering', () => {
+    it('applies risk_level filter from URL parameter', async () => {
+      renderWithProviders(<EventTimeline />, { route: '/timeline?risk_level=high' });
+
+      await waitFor(() => {
+        expect(api.fetchEvents).toHaveBeenCalledWith(
+          expect.objectContaining({ risk_level: 'high', offset: 0 }),
+          expect.anything()
+        );
+      });
+
+      // Filter panel should be visible
+      expect(screen.getByLabelText('Risk Level')).toBeInTheDocument();
+    });
+
+    it('applies camera filter from URL parameter', async () => {
+      renderWithProviders(<EventTimeline />, { route: '/timeline?camera=camera-1' });
+
+      await waitFor(() => {
+        expect(api.fetchEvents).toHaveBeenCalledWith(
+          expect.objectContaining({ camera_id: 'camera-1', offset: 0 }),
+          expect.anything()
+        );
+      });
+    });
+
+    it('applies both camera and risk_level filters from URL parameters', async () => {
+      renderWithProviders(<EventTimeline />, {
+        route: '/timeline?camera=camera-1&risk_level=critical',
+      });
+
+      await waitFor(() => {
+        expect(api.fetchEvents).toHaveBeenCalledWith(
+          expect.objectContaining({
+            camera_id: 'camera-1',
+            risk_level: 'critical',
+            offset: 0,
+          }),
+          expect.anything()
+        );
+      });
+    });
+
+    it('shows filter panel when risk_level URL parameter is present', async () => {
+      renderWithProviders(<EventTimeline />, { route: '/timeline?risk_level=medium' });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Risk Level')).toBeInTheDocument();
+      });
+
+      // Filter panel should be visible (showing Hide Filters button)
+      expect(screen.getByText('Hide Filters')).toBeInTheDocument();
+    });
+  });
+
   describe('Event Detail Modal', () => {
     it('opens modal when clicking on event card', async () => {
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/frontend/src/components/events/EventTimeline.tsx
+++ b/frontend/src/components/events/EventTimeline.tsx
@@ -99,17 +99,21 @@ export default function EventTimeline({ onViewEventDetails, className = '' }: Ev
   // URL search params for deep-linking (e.g., /timeline?camera=cam-1)
   const [searchParams] = useSearchParams();
 
-  // Initialize camera filter from URL query parameter
-  // Updates when searchParams changes (e.g., navigating from dashboard camera click)
+  // Initialize filters from URL query parameters
+  // Updates when searchParams changes (e.g., navigating from dashboard camera click or AI Performance risk chart)
   useEffect(() => {
     const cameraParam = searchParams.get('camera');
-    if (cameraParam) {
+    const riskLevelParam = searchParams.get('risk_level');
+
+    // Only update if we have at least one parameter
+    if (cameraParam || riskLevelParam) {
       setFilters((prev) => ({
         ...prev,
-        camera_id: cameraParam,
+        ...(cameraParam && { camera_id: cameraParam }),
+        ...(riskLevelParam && { risk_level: riskLevelParam }),
         offset: 0,
       }));
-      // Show filters panel when coming from dashboard camera click
+      // Show filters panel when coming with URL parameters
       setShowFilters(true);
     }
   }, [searchParams]);

--- a/frontend/src/types/generated/api.ts
+++ b/frontend/src/types/generated/api.ts
@@ -2641,6 +2641,72 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/system/model-zoo/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Model Zoo Status
+         * @description Get status information for all Model Zoo models.
+         *
+         *     Returns status information for all 18 Model Zoo models, including:
+         *     - Current status (loaded, unloaded, disabled)
+         *     - VRAM usage when loaded
+         *     - Last usage timestamp
+         *     - Category grouping for UI display
+         *
+         *     This endpoint is optimized for the compact status card display
+         *     in the AI Performance page.
+         *
+         *     Returns:
+         *         ModelZooStatusResponse with all model statuses
+         */
+        get: operations["get_model_zoo_status_api_system_model_zoo_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/system/model-zoo/latency/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Model Zoo Latency History
+         * @description Get latency history for a specific Model Zoo model.
+         *
+         *     Returns time-series latency data for the dropdown-controlled chart.
+         *     Each bucket contains aggregated statistics (avg, p50, p95).
+         *
+         *     Args:
+         *         model: Model name to get history for
+         *         since: Number of minutes of history to return (default 60)
+         *         bucket_seconds: Size of each time bucket in seconds (default 60)
+         *
+         *     Returns:
+         *         ModelLatencyHistoryResponse with chronologically ordered snapshots
+         *
+         *     Raises:
+         *         HTTPException: 404 if model not found in registry
+         */
+        get: operations["get_model_zoo_latency_history_api_system_model_zoo_latency_history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/cameras/{camera_id}/zones": {
         parameters: {
             query?: never;
@@ -6352,6 +6418,109 @@ export interface components {
             cross_camera: boolean;
         };
         /**
+         * ModelLatencyHistoryResponse
+         * @description Response schema for Model Zoo latency history endpoint.
+         *
+         *     Returns time-series latency data for a specific Model Zoo model.
+         *     Used to populate the dropdown-controlled latency chart.
+         * @example {
+         *       "bucket_seconds": 60,
+         *       "display_name": "YOLO11 License Plate",
+         *       "has_data": true,
+         *       "model_name": "yolo11-license-plate",
+         *       "snapshots": [
+         *         {
+         *           "stats": {
+         *             "avg_ms": 45,
+         *             "p50_ms": 42,
+         *             "p95_ms": 68,
+         *             "sample_count": 15
+         *           },
+         *           "timestamp": "2026-01-04T10:00:00+00:00"
+         *         }
+         *       ],
+         *       "timestamp": "2026-01-04T10:30:00Z",
+         *       "window_minutes": 60
+         *     }
+         */
+        ModelLatencyHistoryResponse: {
+            /**
+             * Model Name
+             * @description Name of the model this data is for
+             */
+            model_name: string;
+            /**
+             * Display Name
+             * @description Human-readable display name
+             */
+            display_name: string;
+            /**
+             * Snapshots
+             * @description Chronologically ordered latency snapshots
+             */
+            snapshots: components["schemas"]["ModelLatencyHistorySnapshot"][];
+            /**
+             * Window Minutes
+             * @description Time window covered by the history
+             */
+            window_minutes: number;
+            /**
+             * Bucket Seconds
+             * @description Bucket size for aggregation
+             */
+            bucket_seconds: number;
+            /**
+             * Has Data
+             * @description Whether any latency data exists for this model
+             */
+            has_data: boolean;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Timestamp when history was retrieved
+             */
+            timestamp: string;
+        };
+        /**
+         * ModelLatencyHistorySnapshot
+         * @description Single time-bucket snapshot of Model Zoo model latency.
+         */
+        ModelLatencyHistorySnapshot: {
+            /**
+             * Timestamp
+             * @description Bucket start time (ISO format)
+             */
+            timestamp: string;
+            /** @description Latency statistics for this time bucket (None if no data) */
+            stats?: components["schemas"]["ModelLatencyStageStats"] | null;
+        };
+        /**
+         * ModelLatencyStageStats
+         * @description Latency statistics for a Model Zoo model at a point in time.
+         */
+        ModelLatencyStageStats: {
+            /**
+             * Avg Ms
+             * @description Average latency in milliseconds
+             */
+            avg_ms: number;
+            /**
+             * P50 Ms
+             * @description 50th percentile (median) latency in milliseconds
+             */
+            p50_ms: number;
+            /**
+             * P95 Ms
+             * @description 95th percentile latency in milliseconds
+             */
+            p95_ms: number;
+            /**
+             * Sample Count
+             * @description Number of samples in this time bucket
+             */
+            sample_count: number;
+        };
+        /**
          * ModelLeaderboardEntry
          * @description Single entry in model leaderboard.
          */
@@ -6484,6 +6653,109 @@ export interface components {
              * @default 0
              */
             load_count: number;
+        };
+        /**
+         * ModelZooStatusItem
+         * @description Status information for a single Model Zoo model.
+         *
+         *     Used in the compact status card display for Model Zoo models.
+         */
+        ModelZooStatusItem: {
+            /**
+             * Name
+             * @description Model identifier (e.g., 'yolo11-license-plate')
+             */
+            name: string;
+            /**
+             * Display Name
+             * @description Human-readable display name
+             */
+            display_name: string;
+            /**
+             * Category
+             * @description Model category (detection, classification, segmentation, etc.)
+             */
+            category: string;
+            /** @description Current status: loaded (green), unloaded (gray), disabled (yellow) */
+            status: components["schemas"]["ModelStatusEnum"];
+            /**
+             * Vram Mb
+             * @description VRAM usage in megabytes when loaded
+             */
+            vram_mb: number;
+            /**
+             * Last Used At
+             * @description Timestamp of last model usage (null if never used)
+             */
+            last_used_at?: string | null;
+            /**
+             * Enabled
+             * @description Whether the model is enabled for use
+             */
+            enabled: boolean;
+        };
+        /**
+         * ModelZooStatusResponse
+         * @description Response schema for Model Zoo status endpoint.
+         *
+         *     Returns status information for all 18 Model Zoo models organized by category.
+         *     Used to populate the compact status cards in the UI.
+         * @example {
+         *       "disabled_count": 3,
+         *       "loaded_count": 0,
+         *       "models": [
+         *         {
+         *           "category": "detection",
+         *           "display_name": "YOLO11 License Plate",
+         *           "enabled": true,
+         *           "name": "yolo11-license-plate",
+         *           "status": "unloaded",
+         *           "vram_mb": 300
+         *         }
+         *       ],
+         *       "timestamp": "2026-01-04T10:30:00Z",
+         *       "total_models": 18,
+         *       "vram_budget_mb": 1650,
+         *       "vram_used_mb": 0
+         *     }
+         */
+        ModelZooStatusResponse: {
+            /**
+             * Models
+             * @description List of all Model Zoo models with their current status
+             */
+            models: components["schemas"]["ModelZooStatusItem"][];
+            /**
+             * Total Models
+             * @description Total number of models in the registry
+             */
+            total_models: number;
+            /**
+             * Loaded Count
+             * @description Number of currently loaded models
+             */
+            loaded_count: number;
+            /**
+             * Disabled Count
+             * @description Number of disabled models
+             */
+            disabled_count: number;
+            /**
+             * Vram Budget Mb
+             * @description Total VRAM budget for Model Zoo
+             */
+            vram_budget_mb: number;
+            /**
+             * Vram Used Mb
+             * @description Currently used VRAM
+             */
+            vram_used_mb: number;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Timestamp of status snapshot
+             */
+            timestamp: string;
         };
         /**
          * NotificationChannel
@@ -11364,6 +11636,62 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ModelStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_model_zoo_status_api_system_model_zoo_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ModelZooStatusResponse"];
+                };
+            };
+        };
+    };
+    get_model_zoo_latency_history_api_system_model_zoo_latency_history_get: {
+        parameters: {
+            query: {
+                /** @description Model name to get latency history for (e.g., 'yolo11-license-plate') */
+                model: string;
+                /** @description Number of minutes of history to return (1-1440, i.e., 1 minute to 24 hours) */
+                since?: number;
+                /** @description Size of each time bucket in seconds (10-3600, i.e., 10 seconds to 1 hour) */
+                bucket_seconds?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ModelLatencyHistoryResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/tests/e2e/pages/AIAuditPage.ts
+++ b/frontend/tests/e2e/pages/AIAuditPage.ts
@@ -3,10 +3,10 @@
  *
  * Provides selectors and interactions for:
  * - Quality score metrics
- * - Model contribution chart
- * - Model leaderboard
  * - Recommendations panel
  * - Period selector
+ *
+ * Note: Model contribution chart and leaderboard are now on the AI Performance page
  */
 
 import type { Page, Locator } from '@playwright/test';
@@ -29,13 +29,6 @@ export class AIAuditPage extends BasePage {
   readonly enrichmentUtilizationCard: Locator;
   readonly evaluationCoverageCard: Locator;
 
-  // Model Contribution Chart
-  readonly modelContributionChart: Locator;
-
-  // Model Leaderboard
-  readonly modelLeaderboard: Locator;
-  readonly leaderboardTable: Locator;
-
   // Recommendations Panel
   readonly recommendationsPanel: Locator;
   readonly recommendationsAccordion: Locator;
@@ -50,7 +43,7 @@ export class AIAuditPage extends BasePage {
 
     // Page heading
     this.pageTitle = page.getByRole('heading', { name: /AI Audit Dashboard/i });
-    this.pageSubtitle = page.getByText(/Model contribution rates, quality metrics/i);
+    this.pageSubtitle = page.getByText(/quality metrics/i);
 
     // Controls
     this.periodSelector = page.getByTestId('period-selector');
@@ -62,13 +55,6 @@ export class AIAuditPage extends BasePage {
     this.consistencyRateCard = page.getByTestId('consistency-rate-card');
     this.enrichmentUtilizationCard = page.getByTestId('enrichment-utilization-card');
     this.evaluationCoverageCard = page.getByTestId('evaluation-coverage-card');
-
-    // Model Contribution Chart
-    this.modelContributionChart = page.getByTestId('model-contribution-chart');
-
-    // Model Leaderboard
-    this.modelLeaderboard = page.getByTestId('model-leaderboard');
-    this.leaderboardTable = page.getByTestId('leaderboard-table');
 
     // Recommendations Panel
     this.recommendationsPanel = page.getByTestId('recommendations-panel');
@@ -114,14 +100,6 @@ export class AIAuditPage extends BasePage {
   async selectPeriod(period: '1' | '7' | '14' | '30' | '90'): Promise<void> {
     await this.periodSelector.click();
     await this.page.getByRole('option', { name: new RegExp(period) }).click();
-  }
-
-  /**
-   * Get the number of models in the leaderboard
-   */
-  async getLeaderboardModelCount(): Promise<number> {
-    const rows = this.leaderboardTable.locator('tbody tr');
-    return rows.count();
   }
 
   /**

--- a/frontend/tests/e2e/specs/ai-audit.spec.ts
+++ b/frontend/tests/e2e/specs/ai-audit.spec.ts
@@ -106,61 +106,6 @@ test.describe('AI Audit Quality Metrics', () => {
   });
 });
 
-test.describe('AI Audit Model Contribution Chart', () => {
-  let aiAuditPage: AIAuditPage;
-
-  test.beforeEach(async ({ page }) => {
-    await setupApiMocks(page, defaultMockConfig);
-    aiAuditPage = new AIAuditPage(page);
-    await aiAuditPage.goto();
-    await aiAuditPage.waitForPageLoad();
-  });
-
-  test('model contribution chart is visible', async () => {
-    await aiAuditPage.waitForDataLoad();
-    await expect(aiAuditPage.modelContributionChart).toBeVisible();
-  });
-
-  test('chart has model contribution title', async ({ page }) => {
-    await aiAuditPage.waitForDataLoad();
-    // Use locator.filter to find the text within the contribution chart
-    const chart = page.getByTestId('model-contribution-chart');
-    await expect(chart.getByText(/Contribution/i).first()).toBeVisible({ timeout: 10000 });
-  });
-});
-
-test.describe('AI Audit Model Leaderboard', () => {
-  let aiAuditPage: AIAuditPage;
-
-  test.beforeEach(async ({ page }) => {
-    await setupApiMocks(page, defaultMockConfig);
-    aiAuditPage = new AIAuditPage(page);
-    await aiAuditPage.goto();
-    await aiAuditPage.waitForPageLoad();
-  });
-
-  test('model leaderboard is visible', async () => {
-    await aiAuditPage.waitForDataLoad();
-    await expect(aiAuditPage.modelLeaderboard).toBeVisible();
-  });
-
-  test('leaderboard title says Model Leaderboard', async ({ page }) => {
-    await aiAuditPage.waitForDataLoad();
-    await expect(page.getByText('Model Leaderboard')).toBeVisible();
-  });
-
-  test('leaderboard has model entries', async () => {
-    await aiAuditPage.waitForDataLoad();
-    const modelCount = await aiAuditPage.getLeaderboardModelCount();
-    expect(modelCount).toBeGreaterThan(0);
-  });
-
-  test('leaderboard shows RT-DETR model', async ({ page }) => {
-    await aiAuditPage.waitForDataLoad();
-    await expect(page.getByText('RT-DETR').first()).toBeVisible({ timeout: 10000 });
-  });
-});
-
 test.describe('AI Audit Recommendations Panel', () => {
   let aiAuditPage: AIAuditPage;
 


### PR DESCRIPTION
## Summary
- **NEM-1136**: Move Model Contribution Rates and Leaderboard from AI Audit to AI Performance page
- **NEM-1135**: Make Risk Score Distribution bars clickable to filter Timeline
- **NEM-1129**: Add Model Zoo status panels with latency chart and dropdown selector

## Changes

### AI Performance Page Enhancements
- New "Model Zoo Analytics" section with contribution chart and leaderboard (moved from AI Audit)
- Clickable risk distribution bars with hover effects navigate to `/timeline?risk_level={level}`
- New Model Zoo section with:
  - Dropdown-controlled latency chart (Avg/P50/P95 lines)
  - Models grouped by category in dropdown
  - Compact status cards for 18 models showing loaded/unloaded/disabled state, VRAM, last used time

### Backend API Additions
- `GET /api/system/model-zoo/status` - Returns compact status for all Model Zoo models
- `GET /api/system/model-zoo/latency/history?model={name}&since=60` - Returns time-series latency data
- `ModelLatencyTracker` class for recording and aggregating model latency metrics

### AI Audit Page Simplification
- Removed Model Contribution Rates and Leaderboard (moved to AI Performance)
- Recommendations panel now full width

## Test plan
- [x] Backend unit tests pass (28 new tests for Model Zoo endpoints)
- [x] Frontend component tests pass (27 new tests for ModelZooSection)
- [x] Clickable risk bars navigate correctly
- [x] Timeline reads `risk_level` URL param
- [x] Model Zoo dropdown groups models by category
- [x] Status cards show correct loaded/unloaded/disabled states

🤖 Generated with [Claude Code](https://claude.com/claude-code)