### PR TITLE
fix: add is_degraded() to SystemBroadcaster and fix Trivy workflow (NEM-1075, NEM-1126)

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -49,10 +49,12 @@ jobs:
         # Context must be project root because Dockerfile.prod copies pyproject.toml/uv.lock from root
         run: docker build -t backend:${{ github.sha }} -f backend/Dockerfile.prod .
 
-      - name: Clean up Docker to free space
-        # Remove build cache and intermediate layers to maximize space for Trivy
+      - name: Clean up Docker build cache to free space
+        # Remove only build cache and intermediate layers, NOT the built image
+        # IMPORTANT: Don't use 'docker system prune -af' as it deletes ALL unused images
+        # including the image we just built but haven't scanned yet
         run: |
-          docker system prune -af --volumes
+          docker builder prune -af
           df -h
 
       - name: Run Trivy vulnerability scanner (blocking)

--- a/backend/tests/unit/core/test_websocket.py
+++ b/backend/tests/unit/core/test_websocket.py
@@ -232,6 +232,7 @@ class MockSystemBroadcaster:
     - start_broadcasting(interval=5.0) -> None
     - stop_broadcasting() -> None
     - get_circuit_state() -> str
+    - is_degraded() -> bool
     """
 
     def __init__(
@@ -344,6 +345,14 @@ class MockSystemBroadcaster:
             Circuit breaker state string (e.g., "closed", "open", "half_open")
         """
         return "closed"  # Mock always returns healthy state
+
+    def is_degraded(self) -> bool:
+        """Check if the broadcaster is in degraded mode.
+
+        Returns:
+            True if broadcaster is in degraded mode, False otherwise
+        """
+        return False  # Mock always returns healthy state
 
     # ==========================================================================
     # Test-only methods below - NOT part of the real SystemBroadcaster interface


### PR DESCRIPTION
## Summary

- **NEM-1075**: Add `is_degraded()` method to `SystemBroadcaster` matching `EventBroadcaster` interface
- **NEM-1126**: Fix Trivy workflow deleting built images before scanning

## Changes

### NEM-1075: SystemBroadcaster.is_degraded()
- Add `_is_degraded` flag to track degraded mode
- Add `is_degraded()` method for consistent broadcaster interface
- Set degraded flag when recovery attempts exhausted or circuit breaker blocks
- Clear degraded flag on successful pub/sub listener start
- Add 6 comprehensive tests for is_degraded() behavior
- Update MockSystemBroadcaster to include is_degraded() method

### NEM-1126: Trivy Workflow Fix
- Replace `docker system prune -af --volumes` with `docker builder prune -af`
- The system prune was deleting ALL unused images including the one just built but not yet scanned
- Builder prune only removes build cache, preserving the image for Trivy scanning

## Test plan
- [x] All 75 system_broadcaster tests pass
- [x] Mock interface compatibility test passes
- [x] Pre-push hooks pass (unit tests, linting, type checking)
- [x] No duplicate work with already-merged PRs #1271, #1272, #1273

🤖 Generated with [Claude Code](https://claude.com/claude-code)