### PR TITLE
fix: add postgres/redis services to contract tests CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,6 +532,29 @@ jobs:
     name: Contract Tests (API Schema)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: security_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -552,9 +575,12 @@ jobs:
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/security_test
           REDIS_URL: redis://localhost:6379/15
+          REDIS_HOST: localhost
+          REDIS_PORT: 6379
         run: |
           uv run pytest backend/tests/contracts/ \
             -n0 \
+            --timeout=30 \
             -v \
             --junit-xml=test-results-contracts.xml \
             --durations=10

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -192,7 +192,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 602
+        "line_number": 628
       }
     ],
     "backend/AGENTS.md": [
@@ -3037,5 +3037,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-05T02:03:03Z"
+  "generated_at": "2026-01-05T02:08:35Z"
 }


### PR DESCRIPTION
## Summary

Contract tests were timing out because they need the database and Redis services to be available even though the app dependencies are mocked. The FastAPI app startup may still try to connect to these services.

## Changes

- Add postgres and redis service containers to contract-tests job
- Add REDIS_HOST and REDIS_PORT env vars
- Add --timeout=30 to prevent indefinite hangs

## Test plan

- [ ] CI contract tests job passes
- [ ] All other CI jobs continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)