### PR TITLE
feat(resilience): implement circuit breakers and frontend recovery (NEM-1394)

### DIFF
--- a/backend/core/circuit_breaker.py
+++ b/backend/core/circuit_breaker.py
@@ -1,0 +1,355 @@
+"""Shared circuit breaker utility for AI services.
+
+This module provides a reusable CircuitBreaker class that implements the circuit
+breaker pattern for protecting AI service calls. It prevents cascading failures
+by temporarily stopping requests to failing services and allowing them time to
+recover.
+
+States:
+    - CLOSED: Normal operation, requests proceed normally
+    - OPEN: Too many failures, requests are blocked to allow recovery
+    - HALF_OPEN: Testing recovery, limited requests allowed
+
+Features:
+    - Configurable failure thresholds and recovery timeouts
+    - Half-open state for gradual recovery testing
+    - Thread-safe with asyncio Lock
+    - Prometheus metrics integration for monitoring
+    - Logging of state transitions
+
+Usage:
+    from backend.core.circuit_breaker import CircuitBreaker
+
+    class FlorenceClient:
+        def __init__(self):
+            self.circuit_breaker = CircuitBreaker(
+                name="florence",
+                failure_threshold=5,
+                recovery_timeout=60,
+                half_open_max_calls=3
+            )
+
+        async def call_api(self):
+            if not self.circuit_breaker.allow_request():
+                raise ServiceUnavailable("Florence circuit open")
+            try:
+                result = await self._make_request()
+                self.circuit_breaker.record_success()
+                return result
+            except Exception as e:
+                self.circuit_breaker.record_failure()
+                raise
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime
+from enum import Enum
+
+from prometheus_client import Counter, Gauge
+
+from backend.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class CircuitState(Enum):
+    """Circuit breaker states."""
+
+    CLOSED = "closed"  # Normal operation
+    OPEN = "open"  # Rejecting requests, waiting to recover
+    HALF_OPEN = "half_open"  # Testing recovery
+
+
+# =============================================================================
+# Prometheus Metrics
+# =============================================================================
+
+CIRCUIT_BREAKER_STATE = Gauge(
+    "circuit_breaker_state",
+    "Current state of the circuit breaker (0=closed, 1=open, 2=half_open)",
+    labelnames=["service"],
+)
+
+CIRCUIT_BREAKER_FAILURES_TOTAL = Counter(
+    "circuit_breaker_failures_total",
+    "Total number of failures recorded by the circuit breaker",
+    labelnames=["service"],
+)
+
+CIRCUIT_BREAKER_STATE_CHANGES_TOTAL = Counter(
+    "circuit_breaker_state_changes_total",
+    "Total number of state transitions",
+    labelnames=["service", "from_state", "to_state"],
+)
+
+
+class CircuitBreaker:
+    """Circuit breaker for AI service calls.
+
+    Implements the circuit breaker pattern to protect against cascading failures
+    when calling external AI services like Florence, RT-DETR, or Nemotron.
+
+    When a service experiences repeated failures, the circuit breaker opens to
+    prevent further failed attempts and allows time for recovery.
+
+    Attributes:
+        name: Service identifier for metrics and logging
+        failure_threshold: Number of consecutive failures before opening circuit
+        recovery_timeout: Seconds to wait before attempting half-open state
+        half_open_max_calls: Maximum calls allowed in half-open state
+    """
+
+    def __init__(
+        self,
+        name: str,
+        failure_threshold: int = 5,
+        recovery_timeout: float = 60.0,
+        half_open_max_calls: int = 3,
+    ) -> None:
+        """Initialize circuit breaker.
+
+        Args:
+            name: Service identifier for metrics and logging
+            failure_threshold: Number of consecutive failures before opening circuit
+            recovery_timeout: Seconds to wait before transitioning to half-open
+            half_open_max_calls: Maximum calls allowed in half-open state
+        """
+        self._name = name
+        self._failure_threshold = failure_threshold
+        self._recovery_timeout = recovery_timeout
+        self._half_open_max_calls = half_open_max_calls
+
+        # State tracking
+        self._state = CircuitState.CLOSED
+        self._failure_count = 0
+        self._success_count = 0
+        self._half_open_calls = 0
+
+        # Timing tracking
+        self._opened_at: float | None = None
+        self._last_state_change: datetime | None = None
+
+        # Thread safety
+        self._lock = asyncio.Lock()
+
+        # Initialize metrics
+        CIRCUIT_BREAKER_STATE.labels(service=name).set(0)
+
+        logger.info(
+            f"CircuitBreaker '{name}' initialized: "
+            f"failure_threshold={failure_threshold}, "
+            f"recovery_timeout={recovery_timeout}s, "
+            f"half_open_max_calls={half_open_max_calls}"
+        )
+
+    def get_state(self) -> CircuitState:
+        """Get current circuit state.
+
+        Returns:
+            Current CircuitState
+        """
+        return self._state
+
+    def allow_request(self) -> bool:
+        """Check if a request should proceed based on current state.
+
+        This method also handles state transitions from OPEN to HALF_OPEN
+        when the recovery timeout has elapsed.
+
+        Returns:
+            True if request should proceed, False if it should be rejected
+        """
+        if self._state == CircuitState.CLOSED:
+            return True
+
+        if self._state == CircuitState.OPEN:
+            if self._should_attempt_recovery():
+                self._transition_to_half_open()
+                self._half_open_calls += 1
+                return True
+            return False
+
+        if self._state == CircuitState.HALF_OPEN:
+            # Limit concurrent calls in half-open state
+            if self._half_open_calls < self._half_open_max_calls:
+                self._half_open_calls += 1
+                return True
+            return False
+
+        return False
+
+    async def allow_request_async(self) -> bool:
+        """Check if a request should proceed (async version with lock).
+
+        Thread-safe version that acquires a lock before checking state
+        and potentially transitioning.
+
+        Returns:
+            True if request should proceed, False if it should be rejected
+        """
+        async with self._lock:
+            return self.allow_request()
+
+    def record_success(self) -> None:
+        """Record a successful operation.
+
+        Resets failure count and may transition circuit from HALF_OPEN to CLOSED.
+        """
+        if self._state == CircuitState.HALF_OPEN:
+            self._success_count += 1
+            logger.debug(
+                f"CircuitBreaker '{self._name}' half-open success: {self._success_count}/1"
+            )
+
+            # Any success in half-open closes the circuit
+            self._transition_to_closed()
+
+        elif self._state == CircuitState.CLOSED:
+            # Reset failure count on success in closed state
+            if self._failure_count > 0:
+                logger.debug(f"CircuitBreaker '{self._name}' resetting failure count on success")
+                self._failure_count = 0
+
+    async def record_success_async(self) -> None:
+        """Record a successful operation (async version with lock)."""
+        async with self._lock:
+            self.record_success()
+
+    def record_failure(self) -> None:
+        """Record a failed operation.
+
+        Increments failure count and may transition circuit to OPEN state.
+        """
+        self._failure_count += 1
+        CIRCUIT_BREAKER_FAILURES_TOTAL.labels(service=self._name).inc()
+
+        logger.warning(
+            f"CircuitBreaker '{self._name}' failure recorded: "
+            f"{self._failure_count}/{self._failure_threshold}"
+        )
+
+        if self._state == CircuitState.HALF_OPEN:
+            # Any failure in half-open reopens the circuit
+            self._transition_to_open()
+        elif self._state == CircuitState.CLOSED and self._failure_count >= self._failure_threshold:
+            self._transition_to_open()
+
+    async def record_failure_async(self) -> None:
+        """Record a failed operation (async version with lock)."""
+        async with self._lock:
+            self.record_failure()
+
+    def reset(self) -> None:
+        """Manually reset circuit breaker to CLOSED state.
+
+        This clears all failure counts and returns the circuit to normal operation.
+        Use this after fixing underlying issues or for maintenance.
+        """
+        prev_state = self._state
+        self._state = CircuitState.CLOSED
+        self._failure_count = 0
+        self._success_count = 0
+        self._opened_at = None
+        self._half_open_calls = 0
+        self._last_state_change = datetime.now(UTC)
+
+        # Update metrics
+        CIRCUIT_BREAKER_STATE.labels(service=self._name).set(0)
+        if prev_state != CircuitState.CLOSED:
+            CIRCUIT_BREAKER_STATE_CHANGES_TOTAL.labels(
+                service=self._name,
+                from_state=prev_state.value,
+                to_state="closed",
+            ).inc()
+
+        logger.info(f"CircuitBreaker '{self._name}' manually reset to CLOSED")
+
+    async def reset_async(self) -> None:
+        """Manually reset circuit breaker to CLOSED state (async version with lock)."""
+        async with self._lock:
+            self.reset()
+
+    def _should_attempt_recovery(self) -> bool:
+        """Check if recovery timeout has elapsed."""
+        if self._opened_at is None:
+            return False
+        elapsed = time.monotonic() - self._opened_at
+        return elapsed >= self._recovery_timeout
+
+    def _transition_to_open(self) -> None:
+        """Transition circuit to OPEN state."""
+        prev_state = self._state
+        self._state = CircuitState.OPEN
+        self._opened_at = time.monotonic()
+        self._success_count = 0
+        self._half_open_calls = 0
+        self._last_state_change = datetime.now(UTC)
+
+        # Update metrics
+        CIRCUIT_BREAKER_STATE.labels(service=self._name).set(1)
+        CIRCUIT_BREAKER_STATE_CHANGES_TOTAL.labels(
+            service=self._name,
+            from_state=prev_state.value,
+            to_state="open",
+        ).inc()
+
+        logger.warning(
+            f"CircuitBreaker '{self._name}' transitioned {prev_state.value} -> OPEN "
+            f"(failures={self._failure_count}, threshold={self._failure_threshold})"
+        )
+
+    def _transition_to_half_open(self) -> None:
+        """Transition circuit to HALF_OPEN state."""
+        self._state = CircuitState.HALF_OPEN
+        self._success_count = 0
+        self._half_open_calls = 0
+        self._last_state_change = datetime.now(UTC)
+
+        # Update metrics
+        CIRCUIT_BREAKER_STATE.labels(service=self._name).set(2)
+        CIRCUIT_BREAKER_STATE_CHANGES_TOTAL.labels(
+            service=self._name,
+            from_state="open",
+            to_state="half_open",
+        ).inc()
+
+        logger.info(
+            f"CircuitBreaker '{self._name}' transitioned OPEN -> HALF_OPEN "
+            f"(testing recovery after {self._recovery_timeout}s)"
+        )
+
+    def _transition_to_closed(self) -> None:
+        """Transition circuit to CLOSED state."""
+        self._state = CircuitState.CLOSED
+        self._failure_count = 0
+        self._success_count = 0
+        self._opened_at = None
+        self._half_open_calls = 0
+        self._last_state_change = datetime.now(UTC)
+
+        # Update metrics
+        CIRCUIT_BREAKER_STATE.labels(service=self._name).set(0)
+        CIRCUIT_BREAKER_STATE_CHANGES_TOTAL.labels(
+            service=self._name,
+            from_state="half_open",
+            to_state="closed",
+        ).inc()
+
+        logger.info(
+            f"CircuitBreaker '{self._name}' transitioned HALF_OPEN -> CLOSED (service recovered)"
+        )
+
+    def __str__(self) -> str:
+        """String representation of circuit breaker."""
+        return f"CircuitBreaker({self._name}, state={self._state.value.upper()})"
+
+    def __repr__(self) -> str:
+        """Detailed representation of circuit breaker."""
+        return (
+            f"CircuitBreaker(name={self._name!r}, "
+            f"state={self._state.value}, "
+            f"failures={self._failure_count})"
+        )

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -25,10 +25,10 @@ class Settings(BaseSettings):
 
     # Database configuration
     # PostgreSQL only - required for production and development
-    # Example: postgresql+asyncpg://security:password@localhost:5432/security
+    # Example: postgresql+asyncpg://security:password@localhost:5432/security  # pragma: allowlist secret
     database_url: str = Field(
         default="",
-        description="PostgreSQL database URL (format: postgresql+asyncpg://user:pass@host:port/db)",
+        description="PostgreSQL database URL (format: postgresql+asyncpg://user:pass@host:port/db)",  # pragma: allowlist secret
     )
 
     # Database connection pool settings
@@ -543,6 +543,66 @@ class Settings(BaseSettings):
         description="Successful DLQ writes needed to close circuit from half-open state",
     )
 
+    # Enrichment circuit breaker settings
+    enrichment_cb_failure_threshold: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description="Number of Enrichment service failures before opening circuit breaker",
+    )
+    enrichment_cb_recovery_timeout: float = Field(
+        default=60.0,
+        ge=10.0,
+        le=600.0,
+        description="Seconds to wait before attempting Enrichment service calls again after circuit opens",
+    )
+    enrichment_cb_half_open_max_calls: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Maximum test calls allowed when Enrichment circuit is half-open",
+    )
+
+    # CLIP circuit breaker settings
+    clip_cb_failure_threshold: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description="Number of CLIP service failures before opening circuit breaker",
+    )
+    clip_cb_recovery_timeout: float = Field(
+        default=60.0,
+        ge=10.0,
+        le=600.0,
+        description="Seconds to wait before attempting CLIP service calls again after circuit opens",
+    )
+    clip_cb_half_open_max_calls: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Maximum test calls allowed when CLIP circuit is half-open",
+    )
+
+    # Florence circuit breaker settings
+    florence_cb_failure_threshold: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description="Number of Florence service failures before opening circuit breaker",
+    )
+    florence_cb_recovery_timeout: float = Field(
+        default=60.0,
+        ge=10.0,
+        le=600.0,
+        description="Seconds to wait before attempting Florence service calls again after circuit opens",
+    )
+    florence_cb_half_open_max_calls: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Maximum test calls allowed when Florence circuit is half-open",
+    )
+
     # Queue settings
     queue_max_size: int = Field(
         default=10000,
@@ -940,7 +1000,7 @@ class Settings(BaseSettings):
             raise ValueError(
                 "DATABASE_URL environment variable is required. "
                 "Set it in your .env file or environment. "
-                "Example: DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/dbname"
+                "Example: DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/dbname"  # pragma: allowlist secret
             )
         if not v.startswith(("postgresql://", "postgresql+asyncpg://")):
             raise ValueError(

--- a/backend/tests/unit/core/test_circuit_breaker.py
+++ b/backend/tests/unit/core/test_circuit_breaker.py
@@ -1,0 +1,849 @@
+"""Unit tests for the shared Circuit Breaker utility.
+
+Tests cover:
+- State machine transitions (CLOSED -> OPEN -> HALF_OPEN -> CLOSED)
+- Failure count thresholds
+- Recovery timeout behavior
+- Success/failure tracking in different states
+- Prometheus metrics integration
+- Reset functionality
+- Thread-safe async operations
+- Concurrent access patterns
+
+Uses time mocking for deterministic timeout testing.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.core.circuit_breaker import (
+    CircuitBreaker,
+    CircuitState,
+)
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def circuit_breaker() -> CircuitBreaker:
+    """Create a circuit breaker with default settings."""
+    return CircuitBreaker(
+        name="test_service",
+        failure_threshold=5,
+        recovery_timeout=60.0,
+        half_open_max_calls=3,
+    )
+
+
+@pytest.fixture
+def low_threshold_breaker() -> CircuitBreaker:
+    """Create a circuit breaker with low thresholds for faster testing."""
+    return CircuitBreaker(
+        name="low_threshold",
+        failure_threshold=2,
+        recovery_timeout=5.0,
+        half_open_max_calls=2,
+    )
+
+
+@pytest.fixture
+def florence_breaker() -> CircuitBreaker:
+    """Create a circuit breaker configured like the Florence client example."""
+    return CircuitBreaker(
+        name="florence",
+        failure_threshold=5,
+        recovery_timeout=60,
+        half_open_max_calls=3,
+    )
+
+
+# =============================================================================
+# CircuitState Enum Tests
+# =============================================================================
+
+
+class TestCircuitState:
+    """Tests for CircuitState enum."""
+
+    def test_state_values(self) -> None:
+        """Test that state enum has correct values."""
+        assert CircuitState.CLOSED.value == "closed"
+        assert CircuitState.OPEN.value == "open"
+        assert CircuitState.HALF_OPEN.value == "half_open"
+
+    def test_states_are_distinct(self) -> None:
+        """Test that all states are distinct."""
+        states = [CircuitState.CLOSED, CircuitState.OPEN, CircuitState.HALF_OPEN]
+        assert len(states) == len(set(states))
+
+
+# =============================================================================
+# Circuit Breaker Initialization Tests
+# =============================================================================
+
+
+class TestCircuitBreakerInitialization:
+    """Tests for circuit breaker initialization."""
+
+    def test_initial_state_is_closed(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that initial state is CLOSED."""
+        assert circuit_breaker.get_state() == CircuitState.CLOSED
+
+    def test_initial_failure_count_is_zero(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that initial failure count is zero."""
+        assert circuit_breaker._failure_count == 0
+
+    def test_constructor_parameters(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that constructor parameters are stored correctly."""
+        assert circuit_breaker._name == "test_service"
+        assert circuit_breaker._failure_threshold == 5
+        assert circuit_breaker._recovery_timeout == 60.0
+        assert circuit_breaker._half_open_max_calls == 3
+
+    def test_default_parameters(self) -> None:
+        """Test default parameter values."""
+        cb = CircuitBreaker(name="default_test")
+        assert cb._failure_threshold == 5
+        assert cb._recovery_timeout == 60.0
+        assert cb._half_open_max_calls == 3
+
+    def test_custom_parameters(self) -> None:
+        """Test custom parameter values."""
+        cb = CircuitBreaker(
+            name="custom",
+            failure_threshold=10,
+            recovery_timeout=120.0,
+            half_open_max_calls=5,
+        )
+        assert cb._failure_threshold == 10
+        assert cb._recovery_timeout == 120.0
+        assert cb._half_open_max_calls == 5
+
+
+# =============================================================================
+# State Transition Tests: CLOSED -> OPEN
+# =============================================================================
+
+
+class TestClosedToOpenTransition:
+    """Tests for CLOSED to OPEN state transitions."""
+
+    def test_stays_closed_below_threshold(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that circuit stays CLOSED below failure threshold."""
+        circuit_breaker.record_failure()
+        circuit_breaker.record_failure()
+        circuit_breaker.record_failure()
+        circuit_breaker.record_failure()
+
+        assert circuit_breaker.get_state() == CircuitState.CLOSED
+        assert circuit_breaker._failure_count == 4
+
+    def test_transitions_to_open_at_threshold(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that circuit transitions to OPEN at failure threshold."""
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        assert circuit_breaker.get_state() == CircuitState.OPEN
+        assert circuit_breaker._failure_count == 5
+
+    def test_success_resets_failure_count_in_closed(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that success resets failure count in CLOSED state."""
+        circuit_breaker.record_failure()
+        circuit_breaker.record_failure()
+        circuit_breaker.record_success()
+
+        assert circuit_breaker._failure_count == 0
+        assert circuit_breaker.get_state() == CircuitState.CLOSED
+
+    def test_allow_request_true_when_closed(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that allow_request returns True in CLOSED state."""
+        assert circuit_breaker.allow_request() is True
+
+
+# =============================================================================
+# State Transition Tests: OPEN State Behavior
+# =============================================================================
+
+
+class TestOpenStateBehavior:
+    """Tests for behavior in OPEN state."""
+
+    def test_allow_request_false_when_open(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that allow_request returns False in OPEN state."""
+        # Trigger OPEN state
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        assert circuit_breaker.get_state() == CircuitState.OPEN
+        assert circuit_breaker.allow_request() is False
+
+    def test_multiple_requests_rejected_when_open(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that multiple requests are rejected in OPEN state."""
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        # All subsequent requests should be rejected
+        for _ in range(10):
+            assert circuit_breaker.allow_request() is False
+
+
+# =============================================================================
+# State Transition Tests: OPEN -> HALF_OPEN
+# =============================================================================
+
+
+class TestOpenToHalfOpenTransition:
+    """Tests for OPEN to HALF_OPEN state transitions."""
+
+    def test_transitions_to_half_open_after_timeout(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that circuit transitions to HALF_OPEN after recovery timeout."""
+        # Trigger OPEN state
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        assert circuit_breaker.get_state() == CircuitState.OPEN
+
+        # Simulate time passing beyond recovery timeout
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = circuit_breaker._opened_at + 65.0
+
+            # allow_request triggers the transition
+            is_permitted = circuit_breaker.allow_request()
+
+        assert is_permitted is True
+        assert circuit_breaker.get_state() == CircuitState.HALF_OPEN
+
+    def test_stays_open_before_timeout(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that circuit stays OPEN before recovery timeout."""
+        # Trigger OPEN state
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        opened_at = circuit_breaker._opened_at
+
+        # Simulate time still within recovery timeout
+        with patch("time.monotonic", return_value=opened_at + 30.0):
+            is_permitted = circuit_breaker.allow_request()
+
+        assert is_permitted is False
+        assert circuit_breaker.get_state() == CircuitState.OPEN
+
+
+# =============================================================================
+# State Transition Tests: HALF_OPEN -> CLOSED
+# =============================================================================
+
+
+class TestHalfOpenToClosedTransition:
+    """Tests for HALF_OPEN to CLOSED state transitions."""
+
+    def test_success_in_half_open_closes_circuit(
+        self, low_threshold_breaker: CircuitBreaker
+    ) -> None:
+        """Test that success in HALF_OPEN transitions to CLOSED."""
+        # Get to HALF_OPEN state
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+            low_threshold_breaker.allow_request()
+
+        assert low_threshold_breaker.get_state() == CircuitState.HALF_OPEN
+
+        # Success should close the circuit
+        low_threshold_breaker.record_success()
+
+        assert low_threshold_breaker.get_state() == CircuitState.CLOSED
+        assert low_threshold_breaker._failure_count == 0
+
+
+# =============================================================================
+# State Transition Tests: HALF_OPEN -> OPEN
+# =============================================================================
+
+
+class TestHalfOpenToOpenTransition:
+    """Tests for HALF_OPEN to OPEN state transitions."""
+
+    def test_failure_in_half_open_reopens_circuit(
+        self, low_threshold_breaker: CircuitBreaker
+    ) -> None:
+        """Test that failure in HALF_OPEN transitions back to OPEN."""
+        # Get to HALF_OPEN state
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+            low_threshold_breaker.allow_request()
+
+        assert low_threshold_breaker.get_state() == CircuitState.HALF_OPEN
+
+        # Failure should reopen the circuit
+        low_threshold_breaker.record_failure()
+
+        assert low_threshold_breaker.get_state() == CircuitState.OPEN
+
+
+# =============================================================================
+# Half-Open Call Limiting Tests
+# =============================================================================
+
+
+class TestHalfOpenCallLimiting:
+    """Tests for call limiting in HALF_OPEN state."""
+
+    def test_limited_calls_in_half_open(self, low_threshold_breaker: CircuitBreaker) -> None:
+        """Test that calls are limited in HALF_OPEN state."""
+        # Get to HALF_OPEN state
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+
+            # First call is permitted
+            assert low_threshold_breaker.allow_request() is True
+            assert low_threshold_breaker._half_open_calls == 1
+
+            # Second call is permitted (half_open_max_calls=2)
+            assert low_threshold_breaker.allow_request() is True
+            assert low_threshold_breaker._half_open_calls == 2
+
+            # Third call is not permitted (reached max)
+            assert low_threshold_breaker.allow_request() is False
+
+    def test_half_open_calls_counter_resets_on_transition(
+        self, low_threshold_breaker: CircuitBreaker
+    ) -> None:
+        """Test that half_open_calls counter resets when transitioning back to OPEN."""
+        # Get to HALF_OPEN state
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+            low_threshold_breaker.allow_request()
+
+        # Failure in HALF_OPEN transitions back to OPEN
+        low_threshold_breaker.record_failure()
+
+        assert low_threshold_breaker.get_state() == CircuitState.OPEN
+        assert low_threshold_breaker._half_open_calls == 0
+
+
+# =============================================================================
+# Reset Functionality Tests
+# =============================================================================
+
+
+class TestResetFunctionality:
+    """Tests for circuit breaker reset functionality."""
+
+    def test_reset_returns_to_closed(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that reset returns circuit to CLOSED state."""
+        # Get to OPEN state
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        assert circuit_breaker.get_state() == CircuitState.OPEN
+
+        circuit_breaker.reset()
+
+        assert circuit_breaker.get_state() == CircuitState.CLOSED
+
+    def test_reset_clears_failure_count(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that reset clears failure count."""
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        circuit_breaker.reset()
+
+        assert circuit_breaker._failure_count == 0
+
+    def test_reset_clears_opened_at(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that reset clears opened_at timestamp."""
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        assert circuit_breaker._opened_at is not None
+
+        circuit_breaker.reset()
+
+        assert circuit_breaker._opened_at is None
+
+    def test_reset_from_half_open(self, low_threshold_breaker: CircuitBreaker) -> None:
+        """Test that reset works from HALF_OPEN state."""
+        # Get to HALF_OPEN state
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+            low_threshold_breaker.allow_request()
+
+        assert low_threshold_breaker.get_state() == CircuitState.HALF_OPEN
+
+        low_threshold_breaker.reset()
+
+        assert low_threshold_breaker.get_state() == CircuitState.CLOSED
+
+
+# =============================================================================
+# get_state Method Tests
+# =============================================================================
+
+
+class TestGetStateMethod:
+    """Tests for the get_state method."""
+
+    def test_get_state_returns_closed_initially(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that get_state returns CLOSED initially."""
+        assert circuit_breaker.get_state() == CircuitState.CLOSED
+
+    def test_get_state_returns_open_after_failures(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that get_state returns OPEN after threshold failures."""
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        assert circuit_breaker.get_state() == CircuitState.OPEN
+
+    def test_get_state_returns_half_open_after_timeout(
+        self, low_threshold_breaker: CircuitBreaker
+    ) -> None:
+        """Test that get_state returns HALF_OPEN after recovery timeout."""
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+            low_threshold_breaker.allow_request()
+
+        assert low_threshold_breaker.get_state() == CircuitState.HALF_OPEN
+
+
+# =============================================================================
+# Prometheus Metrics Tests
+# =============================================================================
+
+
+class TestPrometheusMetrics:
+    """Tests for Prometheus metrics integration."""
+
+    def test_state_gauge_updated_on_open(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that state gauge is updated when circuit opens."""
+        with patch("backend.core.circuit_breaker.CIRCUIT_BREAKER_STATE") as mock_gauge:
+            mock_labels = MagicMock()
+            mock_gauge.labels.return_value = mock_labels
+
+            for _ in range(5):
+                circuit_breaker.record_failure()
+
+            # Verify gauge was set with correct value (1 for OPEN)
+            mock_gauge.labels.assert_called_with(service="test_service")
+            mock_labels.set.assert_called_with(1)
+
+    def test_state_gauge_updated_on_close(self, low_threshold_breaker: CircuitBreaker) -> None:
+        """Test that state gauge is updated when circuit closes."""
+        # Get to OPEN then HALF_OPEN then CLOSED
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+            low_threshold_breaker.allow_request()
+
+        with patch("backend.core.circuit_breaker.CIRCUIT_BREAKER_STATE") as mock_gauge:
+            mock_labels = MagicMock()
+            mock_gauge.labels.return_value = mock_labels
+
+            low_threshold_breaker.record_success()
+
+            # Verify gauge was set with correct value (0 for CLOSED)
+            mock_labels.set.assert_called_with(0)
+
+    def test_state_gauge_updated_on_half_open(self, low_threshold_breaker: CircuitBreaker) -> None:
+        """Test that state gauge is updated when entering HALF_OPEN."""
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        with (
+            patch("time.monotonic") as mock_time,
+            patch("backend.core.circuit_breaker.CIRCUIT_BREAKER_STATE") as mock_gauge,
+        ):
+            mock_labels = MagicMock()
+            mock_gauge.labels.return_value = mock_labels
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+
+            low_threshold_breaker.allow_request()
+
+            # Verify gauge was set with correct value (2 for HALF_OPEN)
+            mock_labels.set.assert_called_with(2)
+
+    def test_failures_counter_incremented(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that failures counter is incremented on failure."""
+        with patch("backend.core.circuit_breaker.CIRCUIT_BREAKER_FAILURES_TOTAL") as mock_counter:
+            mock_labels = MagicMock()
+            mock_counter.labels.return_value = mock_labels
+
+            circuit_breaker.record_failure()
+
+            mock_counter.labels.assert_called_with(service="test_service")
+            mock_labels.inc.assert_called_once()
+
+    def test_state_changes_counter_incremented_on_transition(
+        self, low_threshold_breaker: CircuitBreaker
+    ) -> None:
+        """Test that state changes counter is incremented on state transitions."""
+        with patch(
+            "backend.core.circuit_breaker.CIRCUIT_BREAKER_STATE_CHANGES_TOTAL"
+        ) as mock_counter:
+            mock_labels = MagicMock()
+            mock_counter.labels.return_value = mock_labels
+
+            # Trigger CLOSED -> OPEN transition
+            for _ in range(2):
+                low_threshold_breaker.record_failure()
+
+            mock_counter.labels.assert_called_with(
+                service="low_threshold", from_state="closed", to_state="open"
+            )
+            mock_labels.inc.assert_called()
+
+
+# =============================================================================
+# Thread Safety Tests
+# =============================================================================
+
+
+class TestThreadSafety:
+    """Tests for thread-safe async operations."""
+
+    @pytest.mark.asyncio
+    async def test_allow_request_async(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test async version of allow_request."""
+        result = await circuit_breaker.allow_request_async()
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_record_success_async(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test async version of record_success."""
+        await circuit_breaker.record_success_async()
+
+        # Should still be in CLOSED state
+        assert circuit_breaker.get_state() == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_record_failure_async(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test async version of record_failure."""
+        await circuit_breaker.record_failure_async()
+
+        assert circuit_breaker._failure_count == 1
+
+    @pytest.mark.asyncio
+    async def test_reset_async(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test async version of reset."""
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        await circuit_breaker.reset_async()
+
+        assert circuit_breaker.get_state() == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_concurrent_failures(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test concurrent failure recording."""
+        import asyncio
+
+        async def record_failures():
+            for _ in range(2):
+                await circuit_breaker.record_failure_async()
+
+        # Run multiple concurrent failure recordings
+        await asyncio.gather(
+            record_failures(),
+            record_failures(),
+            record_failures(),
+        )
+
+        # Should have recorded all failures
+        assert circuit_breaker._failure_count >= 5  # May be 5 or 6 depending on timing
+
+
+# =============================================================================
+# Logging Tests
+# =============================================================================
+
+
+class TestLogging:
+    """Tests for logging behavior."""
+
+    def test_logs_state_transition_to_open(self, low_threshold_breaker: CircuitBreaker) -> None:
+        """Test that state transition to OPEN is logged."""
+        with patch("backend.core.circuit_breaker.logger") as mock_logger:
+            for _ in range(2):
+                low_threshold_breaker.record_failure()
+
+            # Verify warning was logged
+            mock_logger.warning.assert_called()
+            call_args = str(mock_logger.warning.call_args)
+            assert "low_threshold" in call_args
+            assert "OPEN" in call_args
+
+    def test_logs_state_transition_to_half_open(
+        self, low_threshold_breaker: CircuitBreaker
+    ) -> None:
+        """Test that state transition to HALF_OPEN is logged."""
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        with (
+            patch("time.monotonic") as mock_time,
+            patch("backend.core.circuit_breaker.logger") as mock_logger,
+        ):
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+            low_threshold_breaker.allow_request()
+
+            # Verify info was logged
+            mock_logger.info.assert_called()
+            call_args = str(mock_logger.info.call_args)
+            assert "low_threshold" in call_args
+            assert "HALF_OPEN" in call_args
+
+    def test_logs_state_transition_to_closed(self, low_threshold_breaker: CircuitBreaker) -> None:
+        """Test that state transition to CLOSED is logged."""
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+            low_threshold_breaker.allow_request()
+
+        with patch("backend.core.circuit_breaker.logger") as mock_logger:
+            low_threshold_breaker.record_success()
+
+            # Verify info was logged
+            mock_logger.info.assert_called()
+            call_args = str(mock_logger.info.call_args)
+            assert "low_threshold" in call_args
+            assert "CLOSED" in call_args
+
+
+# =============================================================================
+# Complete State Machine Cycle Tests
+# =============================================================================
+
+
+class TestCompleteStateMachineCycle:
+    """Tests for complete state machine cycles."""
+
+    def test_full_cycle_closed_open_half_open_closed(
+        self, low_threshold_breaker: CircuitBreaker
+    ) -> None:
+        """Test a complete cycle through all states."""
+        # Start in CLOSED
+        assert low_threshold_breaker.get_state() == CircuitState.CLOSED
+        assert low_threshold_breaker.allow_request() is True
+
+        # Transition to OPEN
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        assert low_threshold_breaker.get_state() == CircuitState.OPEN
+        assert low_threshold_breaker.allow_request() is False
+
+        # Transition to HALF_OPEN after timeout
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+            is_permitted = low_threshold_breaker.allow_request()
+
+        assert is_permitted is True
+        assert low_threshold_breaker.get_state() == CircuitState.HALF_OPEN
+
+        # Transition back to CLOSED
+        low_threshold_breaker.record_success()
+
+        assert low_threshold_breaker.get_state() == CircuitState.CLOSED
+        assert low_threshold_breaker.allow_request() is True
+        assert low_threshold_breaker._failure_count == 0
+
+    def test_cycle_with_failure_in_half_open(self, low_threshold_breaker: CircuitBreaker) -> None:
+        """Test cycle where failure in HALF_OPEN returns to OPEN."""
+        # Get to OPEN
+        for _ in range(2):
+            low_threshold_breaker.record_failure()
+
+        # Get to HALF_OPEN
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+            low_threshold_breaker.allow_request()
+
+        assert low_threshold_breaker.get_state() == CircuitState.HALF_OPEN
+
+        # Failure returns to OPEN
+        low_threshold_breaker.record_failure()
+
+        assert low_threshold_breaker.get_state() == CircuitState.OPEN
+
+        # Another recovery cycle
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = low_threshold_breaker._opened_at + 10.0
+            low_threshold_breaker.allow_request()
+
+        assert low_threshold_breaker.get_state() == CircuitState.HALF_OPEN
+
+        # Success closes the circuit
+        low_threshold_breaker.record_success()
+
+        assert low_threshold_breaker.get_state() == CircuitState.CLOSED
+
+
+# =============================================================================
+# Florence Client Example Usage Tests
+# =============================================================================
+
+
+class TestFlorenceClientExample:
+    """Tests based on the Florence client example from the issue."""
+
+    def test_florence_breaker_allows_requests_initially(
+        self, florence_breaker: CircuitBreaker
+    ) -> None:
+        """Test that Florence breaker allows requests initially."""
+        assert florence_breaker.allow_request() is True
+
+    def test_florence_breaker_opens_after_5_failures(
+        self, florence_breaker: CircuitBreaker
+    ) -> None:
+        """Test that Florence breaker opens after 5 failures."""
+        for _ in range(5):
+            florence_breaker.record_failure()
+
+        assert florence_breaker.get_state() == CircuitState.OPEN
+        assert florence_breaker.allow_request() is False
+
+    def test_florence_breaker_recovers_after_60_seconds(
+        self, florence_breaker: CircuitBreaker
+    ) -> None:
+        """Test that Florence breaker attempts recovery after 60 seconds."""
+        # Open the circuit
+        for _ in range(5):
+            florence_breaker.record_failure()
+
+        # Simulate 60+ seconds passing
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = florence_breaker._opened_at + 65.0
+            is_permitted = florence_breaker.allow_request()
+
+        assert is_permitted is True
+        assert florence_breaker.get_state() == CircuitState.HALF_OPEN
+
+    def test_florence_breaker_allows_3_half_open_calls(
+        self, florence_breaker: CircuitBreaker
+    ) -> None:
+        """Test that Florence breaker allows 3 calls in half-open state."""
+        # Open the circuit
+        for _ in range(5):
+            florence_breaker.record_failure()
+
+        # Simulate timeout and enter half-open
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = florence_breaker._opened_at + 65.0
+
+            # Should allow exactly 3 calls
+            assert florence_breaker.allow_request() is True
+            assert florence_breaker.allow_request() is True
+            assert florence_breaker.allow_request() is True
+            # Fourth should be rejected
+            assert florence_breaker.allow_request() is False
+
+
+# =============================================================================
+# Edge Cases Tests
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    def test_success_in_closed_with_no_failures(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that success in CLOSED with no failures is a no-op for count."""
+        circuit_breaker.record_success()
+
+        assert circuit_breaker._failure_count == 0
+
+    def test_opened_at_none_before_first_open(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that opened_at is None before circuit opens."""
+        circuit_breaker.record_failure()
+        circuit_breaker.record_failure()
+
+        assert circuit_breaker._opened_at is None
+
+    def test_opened_at_set_when_opened(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that opened_at is set when circuit opens."""
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        assert circuit_breaker._opened_at is not None
+
+    def test_recovery_not_attempted_when_opened_at_is_none(
+        self, circuit_breaker: CircuitBreaker
+    ) -> None:
+        """Test that recovery is not attempted if opened_at is None."""
+        # Manually set state without opened_at
+        circuit_breaker._state = CircuitState.OPEN
+        circuit_breaker._opened_at = None
+
+        result = circuit_breaker._should_attempt_recovery()
+
+        assert result is False
+
+    def test_multiple_reset_calls_are_idempotent(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that multiple reset calls are idempotent."""
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        circuit_breaker.reset()
+        circuit_breaker.reset()
+        circuit_breaker.reset()
+
+        assert circuit_breaker.get_state() == CircuitState.CLOSED
+        assert circuit_breaker._failure_count == 0
+
+
+# =============================================================================
+# String Representation Tests
+# =============================================================================
+
+
+class TestStringRepresentation:
+    """Tests for string representation methods."""
+
+    def test_str_representation(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test __str__ method."""
+        result = str(circuit_breaker)
+
+        assert "test_service" in result
+        assert "CLOSED" in result
+
+    def test_repr_representation(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test __repr__ method."""
+        result = repr(circuit_breaker)
+
+        assert "test_service" in result
+        assert "closed" in result
+        assert "failures=0" in result
+
+    def test_str_changes_with_state(self, circuit_breaker: CircuitBreaker) -> None:
+        """Test that string representation reflects state changes."""
+        for _ in range(5):
+            circuit_breaker.record_failure()
+
+        result = str(circuit_breaker)
+
+        assert "OPEN" in result

--- a/backend/tests/unit/services/test_enrichment_client.py
+++ b/backend/tests/unit/services/test_enrichment_client.py
@@ -58,6 +58,10 @@ def mock_settings() -> MagicMock:
     settings.enrichment_url = "http://test-enrichment:8094"
     settings.ai_connect_timeout = 10.0
     settings.ai_health_timeout = 5.0
+    # Circuit breaker configuration
+    settings.enrichment_cb_failure_threshold = 5
+    settings.enrichment_cb_recovery_timeout = 60.0
+    settings.enrichment_cb_half_open_max_calls = 3
     return settings
 
 
@@ -87,6 +91,10 @@ def client_custom_url() -> EnrichmentClient:
         mock_settings = MagicMock()
         mock_settings.ai_connect_timeout = 10.0
         mock_settings.ai_health_timeout = 5.0
+        # Circuit breaker configuration
+        mock_settings.enrichment_cb_failure_threshold = 5
+        mock_settings.enrichment_cb_recovery_timeout = 60.0
+        mock_settings.enrichment_cb_half_open_max_calls = 3
         mock_settings_fn.return_value = mock_settings
         return EnrichmentClient(base_url="http://custom-enrichment:8888/")
 
@@ -639,6 +647,10 @@ class TestEnrichmentClientInit:
         mock_settings = MagicMock(spec=[])  # No enrichment_url attribute
         mock_settings.ai_connect_timeout = 10.0
         mock_settings.ai_health_timeout = 5.0
+        # Circuit breaker configuration is required
+        mock_settings.enrichment_cb_failure_threshold = 5
+        mock_settings.enrichment_cb_recovery_timeout = 60.0
+        mock_settings.enrichment_cb_half_open_max_calls = 3
         with patch("backend.services.enrichment_client.get_settings", return_value=mock_settings):
             client = EnrichmentClient()
             assert client._base_url == DEFAULT_ENRICHMENT_URL.rstrip("/")

--- a/backend/tests/unit/services/test_enrichment_client_circuit_breaker.py
+++ b/backend/tests/unit/services/test_enrichment_client_circuit_breaker.py
@@ -1,0 +1,485 @@
+"""Unit tests for enrichment client circuit breaker integration.
+
+Tests cover:
+- Circuit breaker initialization with configuration
+- Circuit opens after consecutive failures
+- Requests are rejected when circuit is open
+- Circuit transitions to half-open after recovery timeout
+- Circuit closes after successful request in half-open state
+- Graceful degradation when circuit is open
+- Circuit breaker state is reflected in health check
+- get_circuit_breaker_state() method
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from PIL import Image
+
+from backend.core.circuit_breaker import CircuitState
+from backend.services.enrichment_client import (
+    EnrichmentClient,
+    EnrichmentUnavailableError,
+    reset_enrichment_client,
+)
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_global_client() -> None:
+    """Reset global enrichment client before and after each test."""
+    reset_enrichment_client()
+    yield
+    reset_enrichment_client()
+
+
+@pytest.fixture
+def mock_settings() -> MagicMock:
+    """Create mock settings for testing with circuit breaker config."""
+    settings = MagicMock()
+    settings.enrichment_url = "http://test-enrichment:8094"
+    settings.ai_connect_timeout = 10.0
+    settings.ai_health_timeout = 5.0
+    # Circuit breaker settings
+    settings.enrichment_cb_failure_threshold = 3
+    settings.enrichment_cb_recovery_timeout = 30.0
+    settings.enrichment_cb_half_open_max_calls = 2
+    return settings
+
+
+@pytest.fixture
+def sample_image() -> Image.Image:
+    """Create a sample PIL Image for testing."""
+    return Image.new("RGB", (100, 100), color="red")
+
+
+@pytest.fixture
+def client(mock_settings: MagicMock) -> EnrichmentClient:
+    """Create an EnrichmentClient with mocked settings."""
+    with patch("backend.services.enrichment_client.get_settings", return_value=mock_settings):
+        return EnrichmentClient()
+
+
+# =============================================================================
+# Circuit Breaker Initialization Tests
+# =============================================================================
+
+
+class TestCircuitBreakerInitialization:
+    """Tests for circuit breaker initialization."""
+
+    def test_circuit_breaker_initialized_on_client_creation(self, mock_settings: MagicMock) -> None:
+        """Test that circuit breaker is initialized when client is created."""
+        with patch("backend.services.enrichment_client.get_settings", return_value=mock_settings):
+            client = EnrichmentClient()
+            assert hasattr(client, "_circuit_breaker")
+            assert client._circuit_breaker is not None
+
+    def test_circuit_breaker_uses_config_values(self, mock_settings: MagicMock) -> None:
+        """Test that circuit breaker uses configuration values."""
+        with patch("backend.services.enrichment_client.get_settings", return_value=mock_settings):
+            client = EnrichmentClient()
+            cb = client._circuit_breaker
+            assert cb._failure_threshold == 3
+            assert cb._recovery_timeout == 30.0
+            assert cb._half_open_max_calls == 2
+
+    def test_circuit_breaker_initial_state_is_closed(self, mock_settings: MagicMock) -> None:
+        """Test that circuit breaker starts in CLOSED state."""
+        with patch("backend.services.enrichment_client.get_settings", return_value=mock_settings):
+            client = EnrichmentClient()
+            assert client._circuit_breaker.get_state() == CircuitState.CLOSED
+
+    def test_circuit_breaker_name_is_enrichment(self, mock_settings: MagicMock) -> None:
+        """Test that circuit breaker has correct service name."""
+        with patch("backend.services.enrichment_client.get_settings", return_value=mock_settings):
+            client = EnrichmentClient()
+            assert client._circuit_breaker._name == "enrichment"
+
+
+# =============================================================================
+# Circuit Breaker State Transition Tests
+# =============================================================================
+
+
+class TestCircuitBreakerStateTransitions:
+    """Tests for circuit breaker state transitions during API calls."""
+
+    @pytest.mark.asyncio
+    async def test_circuit_opens_after_consecutive_failures(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that circuit opens after failure threshold is reached."""
+        # Simulate connection failures
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            # Make 3 failing calls (threshold is 3)
+            for _ in range(3):
+                with pytest.raises(EnrichmentUnavailableError):
+                    await client.classify_vehicle(sample_image)
+
+        # Circuit should now be OPEN
+        assert client._circuit_breaker.get_state() == CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_requests_rejected_when_circuit_is_open(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that requests are rejected when circuit is open."""
+        # Force circuit to open
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        assert client._circuit_breaker.get_state() == CircuitState.OPEN
+
+        # Attempt to make a request - should be rejected without making HTTP call
+        with pytest.raises(EnrichmentUnavailableError) as exc_info:
+            await client.classify_vehicle(sample_image)
+
+        assert "circuit open" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_circuit_transitions_to_half_open_after_recovery(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that circuit transitions to HALF_OPEN after recovery timeout."""
+        # Force circuit to open
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        assert client._circuit_breaker.get_state() == CircuitState.OPEN
+
+        # Mock time to simulate recovery timeout
+        original_monotonic = time.monotonic
+        mock_time = original_monotonic() + 35.0  # Beyond recovery timeout (30s)
+
+        with patch("time.monotonic", return_value=mock_time):
+            # allow_request should transition to HALF_OPEN
+            assert client._circuit_breaker.allow_request() is True
+            assert client._circuit_breaker.get_state() == CircuitState.HALF_OPEN
+
+    @pytest.mark.asyncio
+    async def test_circuit_closes_on_success_in_half_open(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that circuit closes on successful request in HALF_OPEN state."""
+        # Force circuit to open
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        # Mock time to trigger HALF_OPEN
+        original_time = time.monotonic()
+
+        with patch("time.monotonic", return_value=original_time + 35.0):
+            # Transition to HALF_OPEN
+            client._circuit_breaker.allow_request()
+            assert client._circuit_breaker.get_state() == CircuitState.HALF_OPEN
+
+            # Record a success
+            client._circuit_breaker.record_success()
+
+            # Circuit should now be CLOSED
+            assert client._circuit_breaker.get_state() == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_successful_request_resets_failure_count(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that successful request resets failure count."""
+        # Add some failures but don't reach threshold
+        client._circuit_breaker.record_failure()
+        client._circuit_breaker.record_failure()
+        assert client._circuit_breaker._failure_count == 2
+
+        # Successful request should reset
+        client._circuit_breaker.record_success()
+        assert client._circuit_breaker._failure_count == 0
+
+
+# =============================================================================
+# Integration Tests - API Methods with Circuit Breaker
+# =============================================================================
+
+
+class TestEnrichmentClientMethodsWithCircuitBreaker:
+    """Tests for enrichment client methods with circuit breaker integration."""
+
+    @pytest.mark.asyncio
+    async def test_classify_vehicle_records_success(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that successful vehicle classification records success."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "vehicle_type": "sedan",
+            "display_name": "Sedan",
+            "confidence": 0.92,
+            "is_commercial": False,
+            "all_scores": {"sedan": 0.92},
+            "inference_time_ms": 42.0,
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            # Add a failure first
+            client._circuit_breaker.record_failure()
+            assert client._circuit_breaker._failure_count == 1
+
+            # Successful call should reset failure count
+            result = await client.classify_vehicle(sample_image)
+
+            assert result is not None
+            assert client._circuit_breaker._failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_classify_pet_records_failure(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that failed pet classification records failure."""
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            with pytest.raises(EnrichmentUnavailableError):
+                await client.classify_pet(sample_image)
+
+            assert client._circuit_breaker._failure_count == 1
+
+    @pytest.mark.asyncio
+    async def test_classify_clothing_respects_circuit_breaker(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that clothing classification respects circuit breaker state."""
+        # Open the circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        # Request should be rejected without making HTTP call
+        with pytest.raises(EnrichmentUnavailableError) as exc_info:
+            await client.classify_clothing(sample_image)
+
+        assert "circuit open" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_estimate_depth_respects_circuit_breaker(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that depth estimation respects circuit breaker state."""
+        # Open the circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        with pytest.raises(EnrichmentUnavailableError) as exc_info:
+            await client.estimate_depth(sample_image)
+
+        assert "circuit open" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_estimate_object_distance_respects_circuit_breaker(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that object distance estimation respects circuit breaker state."""
+        # Open the circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        with pytest.raises(EnrichmentUnavailableError) as exc_info:
+            await client.estimate_object_distance(sample_image, bbox=(10.0, 10.0, 90.0, 90.0))
+
+        assert "circuit open" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_analyze_pose_respects_circuit_breaker(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that pose analysis respects circuit breaker state."""
+        # Open the circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        with pytest.raises(EnrichmentUnavailableError) as exc_info:
+            await client.analyze_pose(sample_image)
+
+        assert "circuit open" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_classify_action_respects_circuit_breaker(self, client: EnrichmentClient) -> None:
+        """Test that action classification respects circuit breaker state."""
+        frames = [Image.new("RGB", (100, 100), color="blue") for _ in range(8)]
+
+        # Open the circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        with pytest.raises(EnrichmentUnavailableError) as exc_info:
+            await client.classify_action(frames)
+
+        assert "circuit open" in str(exc_info.value).lower()
+
+
+# =============================================================================
+# Circuit Breaker State API Tests
+# =============================================================================
+
+
+class TestCircuitBreakerStateAPI:
+    """Tests for circuit breaker state access methods."""
+
+    def test_get_circuit_breaker_state(self, client: EnrichmentClient) -> None:
+        """Test get_circuit_breaker_state method."""
+        assert client.get_circuit_breaker_state() == CircuitState.CLOSED
+
+        # Open circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        assert client.get_circuit_breaker_state() == CircuitState.OPEN
+
+    def test_is_circuit_open(self, client: EnrichmentClient) -> None:
+        """Test is_circuit_open method."""
+        assert client.is_circuit_open() is False
+
+        # Open circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        assert client.is_circuit_open() is True
+
+    def test_reset_circuit_breaker(self, client: EnrichmentClient) -> None:
+        """Test reset_circuit_breaker method."""
+        # Open circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+        assert client.get_circuit_breaker_state() == CircuitState.OPEN
+
+        # Reset
+        client.reset_circuit_breaker()
+
+        assert client.get_circuit_breaker_state() == CircuitState.CLOSED
+        assert client._circuit_breaker._failure_count == 0
+
+
+# =============================================================================
+# Health Check Integration Tests
+# =============================================================================
+
+
+class TestCircuitBreakerHealthCheck:
+    """Tests for circuit breaker state in health checks."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_includes_circuit_breaker_state(
+        self, client: EnrichmentClient
+    ) -> None:
+        """Test that health check includes circuit breaker state."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "healthy", "models": ["vehicle", "pet"]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            result = await client.check_health()
+
+            assert "circuit_breaker_state" in result
+            assert result["circuit_breaker_state"] == "closed"
+
+    @pytest.mark.asyncio
+    async def test_health_check_shows_open_circuit(self, client: EnrichmentClient) -> None:
+        """Test that health check shows circuit open state."""
+        # Open circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "healthy", "models": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            result = await client.check_health()
+
+            assert result["circuit_breaker_state"] == "open"
+
+    @pytest.mark.asyncio
+    async def test_is_healthy_false_when_circuit_open(self, client: EnrichmentClient) -> None:
+        """Test that is_healthy returns False when circuit is open."""
+        # Open circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        # Even if service health check would pass, circuit being open = unhealthy
+        assert await client.is_healthy() is False
+
+
+# =============================================================================
+# Graceful Degradation Tests
+# =============================================================================
+
+
+class TestGracefulDegradation:
+    """Tests for graceful degradation when circuit is open."""
+
+    @pytest.mark.asyncio
+    async def test_no_http_call_when_circuit_open(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that no HTTP call is made when circuit is open."""
+        # Open circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            with pytest.raises(EnrichmentUnavailableError):
+                await client.classify_vehicle(sample_image)
+
+            # Verify no HTTP call was made
+            mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_metrics_recorded_when_circuit_open(
+        self, client: EnrichmentClient, sample_image: Image.Image
+    ) -> None:
+        """Test that metrics are recorded when requests are rejected by circuit."""
+        # Open circuit
+        for _ in range(3):
+            client._circuit_breaker.record_failure()
+
+        with patch("backend.services.enrichment_client.record_pipeline_error") as mock_record:
+            with pytest.raises(EnrichmentUnavailableError):
+                await client.classify_vehicle(sample_image)
+
+            mock_record.assert_called_once_with("enrichment_circuit_open")

--- a/frontend/src/components/common/WebSocketStatus.test.tsx
+++ b/frontend/src/components/common/WebSocketStatus.test.tsx
@@ -562,4 +562,62 @@ describe('WebSocketStatus', () => {
       expect(onRetry).not.toHaveBeenCalled();
     });
   });
+
+  describe('Polling fallback indicator', () => {
+    it('shows polling indicator when isPollingFallback is true', () => {
+      render(
+        <WebSocketStatus
+          eventsChannel={createMockChannel({ name: 'Events', state: 'failed', hasExhaustedRetries: true })}
+          systemChannel={createMockChannel({ name: 'System', state: 'failed', hasExhaustedRetries: true })}
+          isPollingFallback={true}
+        />
+      );
+
+      const pollingIndicator = screen.getByTestId('polling-indicator');
+      expect(pollingIndicator).toBeInTheDocument();
+      expect(pollingIndicator).toHaveTextContent(/polling/i);
+    });
+
+    it('does not show polling indicator when isPollingFallback is false', () => {
+      render(
+        <WebSocketStatus
+          eventsChannel={createMockChannel({ name: 'Events', state: 'connected' })}
+          systemChannel={createMockChannel({ name: 'System', state: 'connected' })}
+          isPollingFallback={false}
+        />
+      );
+
+      expect(screen.queryByTestId('polling-indicator')).not.toBeInTheDocument();
+    });
+
+    it('shows polling indicator when isPollingFallback is true even without explicit prop', () => {
+      render(
+        <WebSocketStatus
+          eventsChannel={createMockChannel({ name: 'Events', state: 'failed', hasExhaustedRetries: true })}
+          systemChannel={createMockChannel({ name: 'System', state: 'failed', hasExhaustedRetries: true })}
+          isPollingFallback={true}
+        />
+      );
+
+      // Should show that we're using REST API polling as fallback
+      const pollingIndicator = screen.getByTestId('polling-indicator');
+      expect(pollingIndicator).toHaveClass('text-blue-400');
+    });
+
+    it('includes polling info in tooltip when in polling fallback mode', () => {
+      render(
+        <WebSocketStatus
+          eventsChannel={createMockChannel({ name: 'Events', state: 'failed', hasExhaustedRetries: true })}
+          systemChannel={createMockChannel({ name: 'System', state: 'failed', hasExhaustedRetries: true })}
+          isPollingFallback={true}
+        />
+      );
+
+      // Hover to show tooltip
+      fireEvent.mouseEnter(screen.getByTestId('websocket-status'));
+
+      const tooltip = screen.getByTestId('websocket-tooltip');
+      expect(tooltip).toHaveTextContent(/REST API/i);
+    });
+  });
 });

--- a/frontend/src/components/common/WebSocketStatus.tsx
+++ b/frontend/src/components/common/WebSocketStatus.tsx
@@ -9,6 +9,8 @@ export interface WebSocketStatusProps {
   showDetails?: boolean;
   /** Optional callback to retry connection after failure */
   onRetry?: () => void;
+  /** Whether currently falling back to REST API polling */
+  isPollingFallback?: boolean;
 }
 
 /**
@@ -173,9 +175,10 @@ interface WebSocketTooltipProps {
   eventsChannel: ChannelStatus;
   systemChannel: ChannelStatus;
   isVisible: boolean;
+  isPollingFallback?: boolean;
 }
 
-function WebSocketTooltip({ eventsChannel, systemChannel, isVisible }: WebSocketTooltipProps) {
+function WebSocketTooltip({ eventsChannel, systemChannel, isVisible, isPollingFallback }: WebSocketTooltipProps) {
   if (!isVisible) {
     return null;
   }
@@ -193,6 +196,13 @@ function WebSocketTooltip({ eventsChannel, systemChannel, isVisible }: WebSocket
         <ChannelIndicator channel={eventsChannel} />
         <ChannelIndicator channel={systemChannel} />
       </div>
+      {isPollingFallback && (
+        <div className="mt-2 border-t border-gray-800 pt-2">
+          <div className="text-xs text-blue-400">
+            Using REST API fallback (auto-reconnect enabled)
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -202,6 +212,7 @@ export default function WebSocketStatus({
   systemChannel,
   showDetails = false,
   onRetry,
+  isPollingFallback = false,
 }: WebSocketStatusProps) {
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const tooltipTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -279,6 +290,13 @@ export default function WebSocketStatus({
         </span>
       )}
 
+      {/* Polling Fallback Indicator */}
+      {isPollingFallback && (
+        <span className="text-xs font-medium text-blue-400" data-testid="polling-indicator">
+          Polling
+        </span>
+      )}
+
       {/* Status Dot */}
       <div
         className={`h-2 w-2 rounded-full ${stateColors.bg} ${overallState === 'connected' ? 'animate-pulse' : ''}`}
@@ -291,6 +309,7 @@ export default function WebSocketStatus({
         eventsChannel={eventsChannel}
         systemChannel={systemChannel}
         isVisible={isTooltipVisible}
+        isPollingFallback={isPollingFallback}
       />
     </div>
   );

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -243,6 +243,7 @@ export default function Header() {
             eventsChannel={summary.eventsChannel}
             systemChannel={summary.systemChannel}
             onRetry={retryConnection}
+            isPollingFallback={isPollingFallback}
           />
         </div>
 

--- a/frontend/src/hooks/useWebSocket.test.ts
+++ b/frontend/src/hooks/useWebSocket.test.ts
@@ -83,7 +83,8 @@ describe('useWebSocket', () => {
       expect.objectContaining({
         reconnect: true,
         reconnectInterval: 1000,
-        maxReconnectAttempts: 5,
+        // Default is now 15 for better backend restart resilience
+        maxReconnectAttempts: 15,
         connectionTimeout: 10000,
         autoRespondToHeartbeat: true,
       })

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -60,7 +60,9 @@ export function useWebSocket(options: WebSocketOptions): UseWebSocketReturn {
     onHeartbeat,
     reconnect = true,
     reconnectInterval = 1000,
-    reconnectAttempts = 5,
+    // Default to 15 attempts for better resilience during backend restarts
+    // With exponential backoff (1s base, 30s max), this provides ~8+ minutes of retry
+    reconnectAttempts = 15,
     connectionTimeout = 10000,
     autoRespondToHeartbeat = true,
   } = options;

--- a/frontend/src/hooks/useWebSocketStatus.test.ts
+++ b/frontend/src/hooks/useWebSocketStatus.test.ts
@@ -615,7 +615,7 @@ describe('useWebSocketStatus', () => {
     expect(mockWsInstances.length).toBe(1);
   });
 
-  it('uses default reconnectAttempts of 5', () => {
+  it('uses default reconnectAttempts of 15 for better backend restart resilience', () => {
     const { result } = renderHook(() =>
       useWebSocketStatus({
         url: 'ws://localhost/ws/test',
@@ -623,7 +623,8 @@ describe('useWebSocketStatus', () => {
       })
     );
 
-    expect(result.current.channelStatus.maxReconnectAttempts).toBe(5);
+    // Default should be 15 to handle backend restarts (up to ~8 minutes with exponential backoff)
+    expect(result.current.channelStatus.maxReconnectAttempts).toBe(15);
   });
 
 });

--- a/frontend/src/hooks/useWebSocketStatus.ts
+++ b/frontend/src/hooks/useWebSocketStatus.ts
@@ -71,7 +71,9 @@ export function useWebSocketStatus(
     onMaxRetriesExhausted,
     reconnect = true,
     reconnectInterval = 1000, // Base interval for exponential backoff
-    reconnectAttempts = 5,
+    // Default to 15 attempts for better resilience during backend restarts
+    // With exponential backoff (1s base, 30s max), this provides ~8+ minutes of retry
+    reconnectAttempts = 15,
     connectionTimeout = 10000, // 10 second connection timeout
   } = options;
 


### PR DESCRIPTION
## Summary

- Implement shared CircuitBreaker utility for AI services with Prometheus metrics
- Integrate circuit breakers into Florence, CLIP, and Enrichment clients
- Improve frontend WebSocket resilience with extended retry window and auto-recovery

## Changes

### Backend
- **New**: `backend/core/circuit_breaker.py` - Reusable circuit breaker with 3 states (CLOSED/OPEN/HALF_OPEN)
- **Modified**: Florence, CLIP, Enrichment clients now have circuit breaker protection
- **Config**: Added `*_cb_failure_threshold`, `*_cb_recovery_timeout`, `*_cb_half_open_max_calls` settings

### Frontend
- WebSocket reconnect attempts: 5 → 15 (~8 min retry window)
- Polling interval during fallback: 30s → 5s
- Auto-recovery when health check succeeds during polling
- Visual "Polling" indicator in WebSocketStatus component

## Test plan
- [x] 53 circuit breaker unit tests (99% coverage)
- [x] 8 Florence integration tests
- [x] 8 CLIP integration tests
- [x] 24 Enrichment integration tests
- [x] Frontend test updates for resilience changes
- [x] All 4,250 frontend tests pass
- [x] Pre-commit and pre-push hooks pass

## Linear Issues
Closes NEM-1273, NEM-1270, NEM-1271, NEM-1272, NEM-1269
Epic: NEM-1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)