### PR TITLE
feat(a11y): fix WCAG 2.1 AA color contrast violations (NEM-1481)

### DIFF
--- a/frontend/src/components/ai/AIAuditPage.tsx
+++ b/frontend/src/components/ai/AIAuditPage.tsx
@@ -153,7 +153,7 @@ export default function AIAuditPage() {
             <p className="mb-4 text-sm text-gray-300">{error}</p>
             <button
               onClick={() => void handleRefresh()}
-              className="rounded-md bg-red-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-600"
+              className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
             >
               Try Again
             </button>

--- a/frontend/src/components/ai/AIPerformancePage.tsx
+++ b/frontend/src/components/ai/AIPerformancePage.tsx
@@ -161,7 +161,7 @@ export default function AIPerformancePage() {
               href={`${grafanaUrl}/d/ai-performance`}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+              className="inline-flex items-center gap-1 font-medium text-blue-400 hover:text-blue-300"
               data-testid="grafana-link"
             >
               Open Grafana
@@ -194,7 +194,7 @@ export default function AIPerformancePage() {
             <p className="mb-4 text-sm text-gray-300">{error}</p>
             <button
               onClick={() => void handleRefresh()}
-              className="rounded-md bg-red-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-600"
+              className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
             >
               Try Again
             </button>

--- a/frontend/src/components/common/AGENTS.md
+++ b/frontend/src/components/common/AGENTS.md
@@ -136,14 +136,16 @@ interface RiskBadgeProps {
 - Pulse animation for critical level (controllable via `animated` prop)
 - Full accessibility: `role="status"` and descriptive `aria-label`
 
-**Color Mapping:**
+**Color Mapping (WCAG 2.1 AA Compliant):**
 
-| Level    | Background        | Text             | Icon          |
-| -------- | ----------------- | ---------------- | ------------- |
-| low      | bg-risk-low/10    | text-risk-low    | CheckCircle   |
-| medium   | bg-risk-medium/10 | text-risk-medium | AlertTriangle |
-| high     | bg-risk-high/10   | text-risk-high   | AlertTriangle |
-| critical | bg-red-500/10     | text-red-500     | AlertOctagon  |
+| Level    | Background            | Text                 | Icon          |
+| -------- | --------------------- | -------------------- | ------------- |
+| low      | bg-risk-low/10        | text-risk-low        | CheckCircle   |
+| medium   | bg-risk-medium/10     | text-risk-medium     | AlertTriangle |
+| high     | bg-risk-high/10       | text-risk-high       | AlertTriangle |
+| critical | bg-risk-critical/10   | text-risk-critical   | AlertOctagon  |
+
+**Note:** Risk colors in `tailwind.config.js` are calibrated to achieve 4.5:1 contrast ratio when text is displayed over semi-transparent backgrounds (bg-{color}/10). The browser blends text color with background, so text colors are brightened to compensate.
 
 **Size Mapping:**
 

--- a/frontend/src/components/common/ChunkLoadErrorBoundary.tsx
+++ b/frontend/src/components/common/ChunkLoadErrorBoundary.tsx
@@ -143,7 +143,7 @@ export default class ChunkLoadErrorBoundary extends Component<
             <button
               type="button"
               onClick={this.handleReload}
-              className="inline-flex items-center gap-2 rounded-md bg-primary-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-900"
+              className="inline-flex items-center gap-2 rounded-md bg-primary-500 px-4 py-2 text-sm font-medium text-gray-950 transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-900"
             >
               <RefreshCw className="h-4 w-4" aria-hidden="true" />
               Reload Page

--- a/frontend/src/components/common/RiskBadge.test.tsx
+++ b/frontend/src/components/common/RiskBadge.test.tsx
@@ -26,11 +26,11 @@ describe('RiskBadge', () => {
       expect(badge.closest('span')).toHaveClass('bg-risk-high/10', 'text-risk-high');
     });
 
-    it('renders critical risk badge with red styling', () => {
+    it('renders critical risk badge with WCAG AA compliant styling', () => {
       render(<RiskBadge level="critical" />);
       const badge = screen.getByText('Critical');
       expect(badge).toBeInTheDocument();
-      expect(badge.closest('span')).toHaveClass('bg-red-500/10', 'text-red-500');
+      expect(badge.closest('span')).toHaveClass('bg-risk-critical/10', 'text-risk-critical');
     });
   });
 
@@ -80,28 +80,30 @@ describe('RiskBadge', () => {
   });
 
   describe('animation', () => {
-    it('applies pulse animation for critical level when animated is true', () => {
+    it('applies pulse-critical animation for critical level when animated is true', () => {
       render(<RiskBadge level="critical" animated={true} />);
       const badge = screen.getByText('Critical');
-      expect(badge.closest('span')).toHaveClass('animate-pulse');
+      // Uses animate-pulse-critical (box-shadow based) instead of animate-pulse (opacity based)
+      // to maintain WCAG 2.1 AA color contrast during animation
+      expect(badge.closest('span')).toHaveClass('animate-pulse-critical');
     });
 
     it('does not apply pulse animation for critical level when animated is false', () => {
       render(<RiskBadge level="critical" animated={false} />);
       const badge = screen.getByText('Critical');
-      expect(badge.closest('span')).not.toHaveClass('animate-pulse');
+      expect(badge.closest('span')).not.toHaveClass('animate-pulse-critical');
     });
 
     it('does not apply pulse animation for non-critical levels', () => {
       render(<RiskBadge level="low" animated={true} />);
       const badge = screen.getByText('Low');
-      expect(badge.closest('span')).not.toHaveClass('animate-pulse');
+      expect(badge.closest('span')).not.toHaveClass('animate-pulse-critical');
     });
 
-    it('applies pulse animation by default for critical level', () => {
+    it('applies pulse-critical animation by default for critical level', () => {
       render(<RiskBadge level="critical" />);
       const badge = screen.getByText('Critical');
-      expect(badge.closest('span')).toHaveClass('animate-pulse');
+      expect(badge.closest('span')).toHaveClass('animate-pulse-critical');
     });
   });
 

--- a/frontend/src/components/common/RiskBadge.tsx
+++ b/frontend/src/components/common/RiskBadge.tsx
@@ -46,14 +46,16 @@ export default function RiskBadge({
   }[size];
 
   // Get color classes based on risk level
+  // Uses WCAG 2.1 AA compliant risk colors from tailwind.config.js
   const colorClasses = {
     low: 'bg-risk-low/10 text-risk-low',
     medium: 'bg-risk-medium/10 text-risk-medium',
     high: 'bg-risk-high/10 text-risk-high',
-    critical: 'bg-red-500/10 text-red-500',
+    critical: 'bg-risk-critical/10 text-risk-critical',
   }[level];
 
-  // Apply pulse animation only for critical level
+  // Apply glow animation only for critical level (uses box-shadow instead of opacity
+  // to maintain WCAG 2.1 AA color contrast during animation)
   const shouldAnimate = animated && level === 'critical';
 
   // Build display text
@@ -74,7 +76,7 @@ export default function RiskBadge({
         'inline-flex items-center gap-1 rounded-full font-medium',
         sizeClasses,
         colorClasses,
-        shouldAnimate && 'animate-pulse',
+        shouldAnimate && 'animate-pulse-critical',
         className
       )}
       data-testid="risk-badge"

--- a/frontend/src/components/dashboard/DashboardPage.tsx
+++ b/frontend/src/components/dashboard/DashboardPage.tsx
@@ -196,7 +196,7 @@ export default function DashboardPage() {
           <p className="text-sm text-gray-300">{error}</p>
           <button
             onClick={() => window.location.reload()}
-            className="mt-4 rounded-md bg-red-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-600"
+            className="mt-4 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
           >
             Reload Page
           </button>

--- a/frontend/src/components/events/ExportPanel.tsx
+++ b/frontend/src/components/events/ExportPanel.tsx
@@ -387,7 +387,7 @@ export default function ExportPanel({
       <Button
         onClick={() => void handleExport()}
         disabled={exporting || stats?.total_events === 0}
-        className="w-full bg-[#76B900] text-white hover:bg-[#5c8f00] disabled:cursor-not-allowed disabled:opacity-50"
+        className="w-full bg-[#76B900] text-gray-950 hover:bg-[#5c8f00] disabled:cursor-not-allowed disabled:opacity-50"
       >
         {exporting ? (
           <>

--- a/frontend/src/components/settings/AlertRulesSettings.tsx
+++ b/frontend/src/components/settings/AlertRulesSettings.tsx
@@ -1301,7 +1301,7 @@ export default function AlertRulesSettings() {
                         void handleDelete();
                       }}
                       disabled={submitting}
-                      className="inline-flex items-center gap-2 rounded-lg bg-red-500 px-4 py-2 font-medium text-white transition-all hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-50"
+                      className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 font-medium text-white transition-all hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-600 disabled:opacity-50"
                     >
                       {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
                       {submitting ? 'Deleting...' : 'Delete Rule'}

--- a/frontend/src/components/settings/CamerasSettings.tsx
+++ b/frontend/src/components/settings/CamerasSettings.tsx
@@ -547,7 +547,7 @@ export default function CamerasSettings() {
                         void handleDelete();
                       }}
                       disabled={submitting}
-                      className="rounded-lg bg-red-500 px-4 py-2 font-medium text-white transition-all hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-50"
+                      className="rounded-lg bg-red-600 px-4 py-2 font-medium text-white transition-all hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-600 disabled:opacity-50"
                     >
                       {submitting ? 'Deleting...' : 'Delete Camera'}
                     </button>

--- a/frontend/src/components/settings/NotificationSettings.tsx
+++ b/frontend/src/components/settings/NotificationSettings.tsx
@@ -126,8 +126,8 @@ export default function NotificationSettings({ className }: NotificationSettings
 
       {error && (
         <div className="mb-4 flex items-center gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-4">
-          <AlertCircle className="h-5 w-5 flex-shrink-0 text-red-500" />
-          <Text className="text-red-500">{error}</Text>
+          <AlertCircle className="h-5 w-5 flex-shrink-0 text-red-400" />
+          <Text className="text-red-400">{error}</Text>
         </div>
       )}
 
@@ -142,9 +142,9 @@ export default function NotificationSettings({ className }: NotificationSettings
           {testResult.success ? (
             <CheckCircle className="h-5 w-5 flex-shrink-0 text-green-500" />
           ) : (
-            <X className="h-5 w-5 flex-shrink-0 text-red-500" />
+            <X className="h-5 w-5 flex-shrink-0 text-red-400" />
           )}
-          <Text className={testResult.success ? 'text-green-500' : 'text-red-500'}>
+          <Text className={testResult.success ? 'text-green-500' : 'text-red-400'}>
             {testResult.message}
           </Text>
         </div>

--- a/frontend/src/components/settings/ProcessingSettings.tsx
+++ b/frontend/src/components/settings/ProcessingSettings.tsx
@@ -298,7 +298,7 @@ export default function ProcessingSettings({ className }: ProcessingSettingsProp
               <Button
                 onClick={() => void handleSave()}
                 disabled={!hasChanges || saving}
-                className="flex-1 bg-[#76B900] text-white hover:bg-[#5c8f00] disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex-1 bg-[#76B900] text-gray-950 hover:bg-[#5c8f00] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <Save className="mr-2 h-4 w-4" />
                 {saving ? 'Saving...' : 'Save Changes'}

--- a/frontend/src/components/settings/SeverityThresholds.tsx
+++ b/frontend/src/components/settings/SeverityThresholds.tsx
@@ -489,7 +489,7 @@ export default function SeverityThresholds({ className }: SeverityThresholdsProp
             <Button
               onClick={() => void handleSave()}
               disabled={!hasChanges || saving || !!validationError}
-              className="flex-1 bg-[#76B900] text-white hover:bg-[#5c8f00] disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex-1 bg-[#76B900] text-gray-950 hover:bg-[#5c8f00] disabled:cursor-not-allowed disabled:opacity-50"
               data-testid="save-thresholds-button"
             >
               <Save className="mr-2 h-4 w-4" />

--- a/frontend/src/components/system/SystemMonitoringPage.tsx
+++ b/frontend/src/components/system/SystemMonitoringPage.tsx
@@ -608,7 +608,7 @@ export default function SystemMonitoringPage() {
           <p className="text-sm text-gray-300">{error}</p>
           <button
             onClick={() => window.location.reload()}
-            className="mt-4 rounded-md bg-red-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-600"
+            className="mt-4 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
           >
             Reload Page
           </button>
@@ -655,7 +655,7 @@ export default function SystemMonitoringPage() {
               href={grafanaUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+              className="inline-flex items-center gap-1 font-medium text-blue-400 hover:text-blue-300"
               data-testid="grafana-link"
             >
               Open Grafana

--- a/frontend/src/components/system/TimeRangeSelector.tsx
+++ b/frontend/src/components/system/TimeRangeSelector.tsx
@@ -60,7 +60,7 @@ export default function TimeRangeSelector({
             className={clsx(
               'rounded-md px-3 py-1.5 text-sm font-medium transition-all duration-150',
               isSelected
-                ? 'bg-[#76B900] text-white shadow-sm'
+                ? 'bg-[#76B900] text-gray-950 shadow-sm' // WCAG 2.1 AA: dark text on green for 4.5:1+ contrast
                 : 'text-gray-400 hover:bg-gray-700/50 hover:text-gray-200'
             )}
           >

--- a/frontend/src/components/zones/ZoneEditor.tsx
+++ b/frontend/src/components/zones/ZoneEditor.tsx
@@ -437,7 +437,7 @@ export default function ZoneEditor({ camera, isOpen, onClose }: ZoneEditorProps)
                         <button
                           onClick={() => void handleDelete()}
                           disabled={isSubmitting}
-                          className="rounded-lg bg-red-500 px-3 py-1.5 text-sm font-medium text-white transition-all hover:bg-red-600 focus:outline-none disabled:opacity-50"
+                          className="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white transition-all hover:bg-red-700 focus:outline-none disabled:opacity-50"
                         >
                           {isSubmitting ? 'Deleting...' : 'Delete'}
                         </button>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -53,8 +53,9 @@
   }
 
   /* Button variants */
+  /* WCAG 2.1 AA: Using dark text on NVIDIA green for 4.5:1+ contrast ratio */
   .btn-primary {
-    @apply rounded-lg bg-primary-500 px-4 py-2 font-medium text-white transition-colors duration-250 hover:bg-primary-600 active:bg-primary-700;
+    @apply rounded-lg bg-primary-500 px-4 py-2 font-medium text-gray-950 transition-colors duration-250 hover:bg-primary-600 active:bg-primary-700;
   }
 
   .btn-secondary {
@@ -63,6 +64,11 @@
 
   .btn-ghost {
     @apply rounded-lg px-4 py-2 font-medium text-text-primary transition-colors duration-250 hover:bg-gray-800 active:bg-gray-700;
+  }
+
+  /* Danger button variant - WCAG 2.1 AA compliant (white on dark red for 4.5:1+ contrast) */
+  .btn-danger {
+    @apply rounded-lg bg-danger px-4 py-2 font-medium text-white transition-colors duration-250 hover:bg-danger-hover active:bg-red-800;
   }
 
   /* Risk badge styles */
@@ -129,6 +135,25 @@
 }
 
 @layer utilities {
+  /* Tremor Badge overrides for WCAG 2.1 AA compliance */
+  /* Gray badges need higher contrast text on dark backgrounds */
+  .bg-gray-500,
+  .dark\:bg-gray-500 {
+    /* Override Tremor's dark gray badge background */
+    background-color: #3A3A3A !important;
+  }
+
+  .text-gray-600,
+  .dark\:text-gray-600 {
+    /* Override Tremor's gray text to meet 4.5:1 contrast */
+    color: #B0B0B0 !important;
+  }
+
+  /* Tremor Badge text class override */
+  .tremor-Badge-text {
+    color: inherit;
+  }
+
   /* Glass morphism effect */
   .glass {
     background: rgba(26, 26, 26, 0.8);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -28,11 +28,32 @@ export default {
           900: '#223A00',
         },
 
-        // Risk Level Colors
+        // Risk Level Colors (WCAG 2.1 AA compliant - 4.5:1 contrast on 10% opacity backgrounds)
+        // Text colors are significantly brightened to meet contrast requirements when used on bg-{color}/10
+        // The browser blends the text color with the semi-transparent background, reducing effective contrast
         risk: {
-          low: '#76B900',
-          medium: '#FFB800',
-          high: '#E74856',
+          low: '#76B900', // Green - good contrast on dark backgrounds
+          medium: '#FFB800', // Amber - good contrast on dark backgrounds
+          high: '#FFCDD2', // Light coral for 4.5:1 contrast on bg-risk-high/10
+          critical: '#FFE0E0', // Very light pink for critical badges - 4.5:1 on blended dark bg
+        },
+
+        // Error/Danger Color (WCAG 2.1 AA compliant - 4.5:1 contrast on dark backgrounds)
+        error: {
+          DEFAULT: '#FF6B6B', // Brightened from #ef4444 for proper contrast on dark bg
+          light: '#FF8585', // For 10% opacity backgrounds
+        },
+
+        // Danger Button Color (WCAG 2.1 AA compliant - 4.5:1 contrast with white text)
+        danger: {
+          DEFAULT: '#DC2626', // Darker red (red-600) for 4.5:1 contrast with white
+          hover: '#B91C1C', // red-700 for hover state
+        },
+
+        // Link Colors (WCAG 2.1 AA compliant for dark theme)
+        link: {
+          DEFAULT: '#60A5FA', // blue-400 equivalent - good contrast on dark
+          hover: '#93C5FD', // blue-300 equivalent
         },
 
         // Text Colors (WCAG 2 AA compliant - 4.5:1 minimum contrast on gray-700)
@@ -115,6 +136,11 @@ export default {
           '0%, 100%': { boxShadow: '0 0 10px rgba(118, 185, 0, 0.2)' },
           '50%': { boxShadow: '0 0 20px rgba(118, 185, 0, 0.4)' },
         },
+        // Critical risk pulse - uses box-shadow instead of opacity to maintain WCAG 2.1 AA contrast
+        'pulse-critical': {
+          '0%, 100%': { boxShadow: '0 0 8px rgba(255, 107, 107, 0.3)' },
+          '50%': { boxShadow: '0 0 16px rgba(255, 107, 107, 0.6)' },
+        },
         'slide-in': {
           '0%': { transform: 'translateX(100%)', opacity: '0' },
           '100%': { transform: 'translateX(0)', opacity: '1' },
@@ -127,6 +153,7 @@ export default {
 
       animation: {
         'pulse-glow': 'pulse-glow 2s ease-in-out infinite',
+        'pulse-critical': 'pulse-critical 2s ease-in-out infinite',
         'slide-in': 'slide-in 0.3s ease-out',
         'fade-in': 'fade-in 0.2s ease-in',
       },

--- a/frontend/tests/e2e/specs/accessibility.spec.ts
+++ b/frontend/tests/e2e/specs/accessibility.spec.ts
@@ -41,22 +41,12 @@ test.beforeEach(async ({ browserName }) => {
 const WCAG_AA_TAGS = ['wcag2a', 'wcag2aa', 'wcag21aa'];
 
 /**
- * Rules to exclude from accessibility checks.
- * Color-contrast is excluded because the NVIDIA dark theme design system has
- * multiple contrast issues that require dedicated design work to fix properly.
- * TODO: Create a Linear ticket to address color contrast issues across the design system.
- * See: https://dequeuniversity.com/rules/axe/4.11/color-contrast
- */
-const EXCLUDED_RULES = ['color-contrast'];
-
-/**
  * Helper function to run axe analysis with standard configuration.
- * Excludes color-contrast checks which require design system updates.
+ * Color-contrast is now enforced after WCAG 2.1 AA compliance fixes (NEM-1481).
  */
 async function runA11yCheck(page: InstanceType<typeof import('@playwright/test').Page>) {
   return new AxeBuilder({ page })
     .withTags(WCAG_AA_TAGS)
-    .disableRules(EXCLUDED_RULES)
     .analyze();
 }
 
@@ -98,7 +88,6 @@ test.describe('Dashboard Page Accessibility', () => {
     // Focus check on the risk card area (replaced RiskGauge with StatsRow risk card)
     const results = await new AxeBuilder({ page })
       .withTags(WCAG_AA_TAGS)
-      .disableRules(EXCLUDED_RULES)
       .include('[data-testid="risk-card"]')
       .analyze();
 

--- a/frontend/tests/e2e/specs/smoke.spec.ts
+++ b/frontend/tests/e2e/specs/smoke.spec.ts
@@ -157,12 +157,9 @@ test.describe('Timeline Event Tests @smoke', () => {
  * These tests use axe-core to verify WCAG 2.1 AA compliance.
  * For comprehensive accessibility testing, see accessibility.spec.ts
  *
- * Note: Color-contrast is excluded because the NVIDIA dark theme design system
- * has multiple contrast issues that require dedicated design work to fix.
+ * Color-contrast is now enforced after WCAG 2.1 AA compliance fixes (NEM-1481).
  */
 test.describe('Accessibility Smoke Tests @smoke @critical', () => {
-  // Rules excluded from a11y checks - see accessibility.spec.ts for details
-  const EXCLUDED_RULES = ['color-contrast'];
 
   test.beforeEach(async ({ page }) => {
     await setupApiMocks(page, defaultMockConfig);
@@ -175,7 +172,6 @@ test.describe('Accessibility Smoke Tests @smoke @critical', () => {
 
     const results = await new AxeBuilder({ page })
       .withTags(WCAG_AA_TAGS)
-      .disableRules(EXCLUDED_RULES)
       .analyze();
 
     // Log violations for debugging if any exist
@@ -196,7 +192,6 @@ test.describe('Accessibility Smoke Tests @smoke @critical', () => {
 
     const results = await new AxeBuilder({ page })
       .withTags(WCAG_AA_TAGS)
-      .disableRules(EXCLUDED_RULES)
       .analyze();
 
     if (results.violations.length > 0) {
@@ -216,7 +211,6 @@ test.describe('Accessibility Smoke Tests @smoke @critical', () => {
 
     const results = await new AxeBuilder({ page })
       .withTags(WCAG_AA_TAGS)
-      .disableRules(EXCLUDED_RULES)
       .analyze();
 
     if (results.violations.length > 0) {


### PR DESCRIPTION
## Summary

- Update Tailwind theme colors to meet WCAG 2.1 AA contrast requirements (4.5:1 ratio)
- Add compliant risk, error, danger, and link colors for dark theme backgrounds
- Re-enable color-contrast rule in E2E accessibility tests
- Update components using hardcoded colors to use theme tokens

Fixes NEM-1481

## Test plan

- [ ] Run `npm test` in frontend - all tests pass
- [ ] Run `npx playwright test accessibility.spec.ts` - color-contrast checks pass
- [ ] Verify risk badges display with proper contrast in browser
- [ ] Verify link colors are readable against dark backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)