### PR TITLE
fix: resolve CI failures in E2E and integration tests

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -78,9 +78,9 @@ export default defineConfig({
   // Global timeout for each test
   timeout: 15000,
 
-  // Global setup script to optimize test startup (future optimization)
-  // This runs once before all tests, reducing per-test overhead
-  // globalSetup: './tests/e2e/global-setup.ts',  // Uncomment when created
+  // Global setup script - disables product tour and sets up shared state
+  // This runs once before all tests, preventing Joyride overlay from blocking interactions
+  globalSetup: './tests/e2e/global-setup.ts',
 
   // Expect timeout - keep short for fast feedback
   // Error state tests use explicit longer timeouts where needed
@@ -120,6 +120,10 @@ export default defineConfig({
 
     // Action timeout (clicks, fills, etc.)
     actionTimeout: 5000,
+
+    // Use storage state from global setup to have product tour disabled
+    // This prevents Joyride overlay from blocking pointer events in tests
+    storageState: 'tests/e2e/.auth/storage-state.json',
 
     // NOTE: launchOptions with --disable-gpu moved to Chromium-specific projects
     // WebKit doesn't support these Chromium-specific flags

--- a/frontend/tests/e2e/.auth/storage-state.json
+++ b/frontend/tests/e2e/.auth/storage-state.json
@@ -1,0 +1,18 @@
+{
+  "cookies": [],
+  "origins": [
+    {
+      "origin": "http://localhost:5173",
+      "localStorage": [
+        {
+          "name": "nemotron-tour-completed",
+          "value": "true"
+        },
+        {
+          "name": "nemotron-tour-skipped",
+          "value": "true"
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/tests/e2e/fixtures/index.ts
+++ b/frontend/tests/e2e/fixtures/index.ts
@@ -48,6 +48,13 @@ export const test = base.extend<{
   // Auto-setup mocks before each test
   autoMock: [
     async ({ page, mockConfig }, use) => {
+      // Disable the product tour to prevent overlay from blocking interactions
+      // The Joyride overlay intercepts pointer events and causes tests to fail
+      await page.addInitScript(() => {
+        localStorage.setItem('nemotron-tour-completed', 'true');
+        localStorage.setItem('nemotron-tour-skipped', 'true');
+      });
+
       await setupApiMocks(page, mockConfig);
       await use();
     },

--- a/frontend/tests/e2e/global-setup.ts
+++ b/frontend/tests/e2e/global-setup.ts
@@ -1,0 +1,53 @@
+/**
+ * Global Setup for E2E Tests
+ *
+ * Runs once before all tests. Used for:
+ * - Setting up shared state
+ * - Disabling UI elements that interfere with tests (like product tour)
+ *
+ * @see https://playwright.dev/docs/test-global-setup-teardown
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function globalSetup() {
+  // Create the storage state file directly without needing a browser
+  // This is more reliable than trying to navigate to the app during setup
+  const storageState = {
+    cookies: [],
+    origins: [
+      {
+        origin: 'http://localhost:5173',
+        localStorage: [
+          {
+            name: 'nemotron-tour-completed',
+            value: 'true',
+          },
+          {
+            name: 'nemotron-tour-skipped',
+            value: 'true',
+          },
+        ],
+      },
+    ],
+  };
+
+  // Ensure the directory exists
+  const authDir = path.join(__dirname, '.auth');
+  if (!fs.existsSync(authDir)) {
+    fs.mkdirSync(authDir, { recursive: true });
+  }
+
+  // Write the storage state file
+  const storagePath = path.join(authDir, 'storage-state.json');
+  fs.writeFileSync(storagePath, JSON.stringify(storageState, null, 2));
+
+  console.log('Global setup: Product tour disabled via storage state');
+}
+
+export default globalSetup;


### PR DESCRIPTION
## Summary

- **E2E Tests (Playwright):** Add global-setup.ts to disable product tour via localStorage, preventing React Joyride overlay from blocking pointer events during tests
- **Integration Tests (API):** Fix enable_service() and disable_service() in ContainerOrchestrator with fallback logic for when lifecycle manager isn't available (e.g., in tests)

## Test plan

- [x] Unit tests pass (59 orchestrator tests, 23 services API tests)
- [x] Pre-commit hooks pass
- [ ] CI E2E tests pass (Chromium shards)
- [ ] CI Integration tests pass (API shard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)