### PR TITLE
fix(e2e): update title assertions and tablet viewport breakpoint

### DIFF
--- a/frontend/tests/e2e/specs/ai-performance.spec.ts
+++ b/frontend/tests/e2e/specs/ai-performance.spec.ts
@@ -150,6 +150,6 @@ test.describe('AI Performance Page Title', () => {
     await setupApiMocks(page, defaultMockConfig);
     const aiPerformancePage = new AIPerformancePage(page);
     await aiPerformancePage.goto();
-    await expect(page).toHaveTitle(/Home Security/i);
+    await expect(page).toHaveTitle(/Security Dashboard/i);
   });
 });

--- a/frontend/tests/e2e/specs/dashboard.spec.ts
+++ b/frontend/tests/e2e/specs/dashboard.spec.ts
@@ -204,10 +204,10 @@ test.describe('Dashboard High Alert State', () => {
 });
 
 test.describe('Dashboard Page Title', () => {
-  test('page title contains Home Security', async ({ page }) => {
+  test('page title contains Security Dashboard', async ({ page }) => {
     await setupApiMocks(page, defaultMockConfig);
     const dashboardPage = new DashboardPage(page);
     await dashboardPage.goto();
-    await expect(page).toHaveTitle(/Home Security/i);
+    await expect(page).toHaveTitle(/Security Dashboard/i);
   });
 });

--- a/frontend/tests/e2e/specs/responsive.spec.ts
+++ b/frontend/tests/e2e/specs/responsive.spec.ts
@@ -10,10 +10,11 @@ import { DashboardPage, TimelinePage, SettingsPage, SystemPage } from '../pages'
 import { setupApiMocks, defaultMockConfig } from '../fixtures';
 
 // Common viewport sizes to test
+// Note: Mobile breakpoint is 768px (max-width), so tablet should be > 768px
 const viewports = {
   mobile: { width: 375, height: 667 }, // iPhone SE
   mobileLarge: { width: 414, height: 896 }, // iPhone 11 Pro Max
-  tablet: { width: 768, height: 1024 }, // iPad
+  tablet: { width: 769, height: 1024 }, // iPad (just above mobile breakpoint)
   tabletLandscape: { width: 1024, height: 768 }, // iPad Landscape
   desktop: { width: 1280, height: 720 }, // Standard desktop
   desktopLarge: { width: 1920, height: 1080 }, // Full HD

--- a/frontend/tests/e2e/specs/smoke.spec.ts
+++ b/frontend/tests/e2e/specs/smoke.spec.ts
@@ -31,7 +31,7 @@ test.describe('Dashboard Smoke Tests @smoke', () => {
 
   test('dashboard page loads successfully', async ({ page }) => {
     await dashboardPage.goto();
-    await expect(page).toHaveTitle(/Home Security/i);
+    await expect(page).toHaveTitle(/Security Dashboard/i);
     await dashboardPage.waitForDashboardLoad();
   });
 
@@ -50,7 +50,7 @@ test.describe('Dashboard Smoke Tests @smoke', () => {
   test('dashboard has correct page title', async ({ page }) => {
     await dashboardPage.goto();
     await dashboardPage.waitForDashboardLoad();
-    await expect(page).toHaveTitle(/Home Security/i);
+    await expect(page).toHaveTitle(/Security Dashboard/i);
   });
 
   test('dashboard shows risk score card', async () => {


### PR DESCRIPTION
## Summary
- Update title regex from `/Home Security/i` to `/Security Dashboard/i` to match actual page title "Nemotron Security Dashboard"
- Fix tablet viewport from 768px to 769px to be above mobile breakpoint (useIsMobile uses max-width: 768px)

## Test plan
- [ ] E2E tests pass in CI (chromium 1-4/4 should all pass now)
- [ ] Responsive tablet tests pass (sidebar visibility test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)