### PR TITLE
ci: add workflow_dispatch trigger for manual CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to CI workflow
- Enables manual CI triggering via GitHub Actions UI or `gh workflow run`
- Needed to retrigger container builds after previous CI run was cancelled

## Test plan
- [ ] Verify workflow accepts manual trigger after merge
- [ ] Confirm containers are published to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)