### PR TITLE
fix(ci): use valid docker/build-push-action SHA in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
       # TODO: Re-enable scanning from registry after push (see option 3 in PR #128)
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@5e57cd118135c172c3672efd75eb46360885c0ef # v6
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ${{ matrix.image.context }}
           file: ${{ matrix.image.dockerfile }}


### PR DESCRIPTION
## Summary
- Fixes invalid docker/build-push-action SHA that was blocking container publish
- Deploy workflow was using non-existent SHA `5e57cd118135c172c3672efd75eb46360885c0ef`
- Updated to use working v5 SHA `ca052bb54ab0790a636c9b5f226502c73d547a25` (same as ci.yml)

## Root Cause
Container publishing to GHCR has been blocked since Jan 6, 2026 because the deploy workflow couldn't download the docker/build-push-action at the invalid SHA.

## Test plan
- [ ] Deploy workflow should successfully build and push containers to GHCR
- [ ] Verify containers in GHCR show new commit SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)