### PR TITLE
feat(frontend): migrate to standardized pagination envelope (NEM-2159)

### DIFF
--- a/frontend/src/test-utils/index.ts
+++ b/frontend/src/test-utils/index.ts
@@ -70,6 +70,8 @@ export {
   createErrorResponse,
   createGPUStatsResponse,
   createEventResponse,
+  // Pagination helpers
+  createPaginationMeta,
 } from './factories';
 
 export type {
@@ -90,4 +92,5 @@ export type {
   CameraListResponse,
   GPUStatsResponse,
   ErrorResponse,
+  PaginationMeta,
 } from './factories';


### PR DESCRIPTION
## Summary

Migrates all frontend API consumers to use the new standardized pagination envelope format introduced in NEM-2075/PR #2443.

### Changes

**Response Format Migration:**
- Entity-specific keys → standardized `response.items`
- Flat pagination fields → nested `response.pagination` object

| Before | After |
|--------|-------|
| `response.cameras` | `response.items` |
| `response.events` | `response.items` |
| `response.detections` | `response.items` |
| `response.alerts` | `response.items` |
| `response.count` | `response.pagination.total` |
| `response.limit` | `response.pagination.limit` |

**Files Updated (34 total):**
- Services: `api.ts`, `abTestService.ts`
- Components: AlertsPage, AuditLogPage, DashboardPage, EventTimeline, ZoneEditor, etc.
- Test files: All corresponding test files with updated mock data
- Generated types: Regenerated from backend OpenAPI spec
- Mock handlers: Updated MSW handlers

### Verification

- ✅ TypeScript check passed
- ✅ All 6,987 tests passing (242 files)
- ✅ Pre-commit hooks passed (ESLint, Prettier)

Closes NEM-2159

## Test plan

- [x] `npm run typecheck` - No TypeScript errors
- [x] `npm test` - All 6,987 tests passing
- [x] Pre-commit hooks pass
- [ ] E2E tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)