### PR TITLE
fix: add pre-commit hook for OpenAPI generation and regenerate specs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,6 +115,17 @@ repos:
         additional_dependencies:
           - prettier@3.2.4
 
+  # OpenAPI spec generation - auto-regenerates docs/openapi.json on backend changes
+  # Runs before commit so the generated spec is included in the commit
+  - repo: local
+    hooks:
+      - id: generate-openapi
+        name: Generate OpenAPI Spec
+        entry: bash -c 'uv run python scripts/generate-openapi.py && git add docs/openapi.json'
+        language: system
+        files: ^backend/(api|models|schemas)/.*\.py$
+        pass_filenames: false
+
   # Frontend Prettier - Uses local prettier with tailwindcss plugin
   # Handles all frontend files: TS/TSX/JS/JSX plus CSS/JSON/MD
   - repo: local

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,1875 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    ".beads/issues.jsonl": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".beads/issues.jsonl",
+        "hashed_secret": "b5816d1465d319d1b4d29cfbc06e1f9c85dae86d",
+        "is_verified": false,
+        "line_number": 256
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".beads/issues.jsonl",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 475
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".beads/issues.jsonl",
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_verified": false,
+        "line_number": 1014
+      }
+    ],
+    "backend/AGENTS.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/AGENTS.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 782
+      }
+    ],
+    "backend/alembic.ini": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/alembic.ini",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 87
+      }
+    ],
+    "backend/alembic/AGENTS.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/alembic/AGENTS.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 84
+      }
+    ],
+    "backend/alembic/env.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/alembic/env.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 33
+      }
+    ],
+    "backend/core/README.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/core/README.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/core/README.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 145
+      }
+    ],
+    "backend/data/AGENTS.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/data/AGENTS.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 82
+      }
+    ],
+    "backend/tests/integration/test_alembic_migrations.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/integration/test_alembic_migrations.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 65
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/integration/test_alembic_migrations.py",
+        "hashed_secret": "5561020ac01fee93a57def5a1d39bdb8954fcb47",
+        "is_verified": false,
+        "line_number": 90
+      }
+    ],
+    "backend/tests/integration/test_circuit_breaker.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/integration/test_circuit_breaker.py",
+        "hashed_secret": "b5816d1465d319d1b4d29cfbc06e1f9c85dae86d",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
+    "backend/tests/integration/test_notification_api.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/integration/test_notification_api.py",
+        "hashed_secret": "1544cdc8fee8460cc268b2c57054f4ec8a83e210",
+        "is_verified": false,
+        "line_number": 66
+      }
+    ],
+    "backend/tests/integration/test_websocket.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/integration/test_websocket.py",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 625
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/integration/test_websocket.py",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 873
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/integration/test_websocket.py",
+        "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
+        "is_verified": false,
+        "line_number": 917
+      }
+    ],
+    "backend/tests/integration/test_websocket_auth.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/integration/test_websocket_auth.py",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/integration/test_websocket_auth.py",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 166
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/integration/test_websocket_auth.py",
+        "hashed_secret": "6b1e40e9988ac99f3ebee3757d2f9d95bb4d3608",
+        "is_verified": false,
+        "line_number": 809
+      }
+    ],
+    "backend/tests/unit/api/routes/test_ai_audit.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/api/routes/test_ai_audit.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "backend/tests/unit/api/routes/test_dlq_api.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/api/routes/test_dlq_api.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
+    "backend/tests/unit/api/routes/test_events_export.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/api/routes/test_events_export.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 606
+      }
+    ],
+    "backend/tests/unit/core/test_auth_middleware.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/core/test_auth_middleware.py",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_auth_middleware.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 32
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/core/test_auth_middleware.py",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 81
+      }
+    ],
+    "backend/tests/unit/core/test_database.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_database.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 470
+      }
+    ],
+    "backend/tests/unit/core/test_database_pool.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_database_pool.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 64
+      }
+    ],
+    "backend/tests/unit/core/test_logging.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 294
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 900
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
+        "is_verified": false,
+        "line_number": 907
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "a761ce3a45d97e41840a788495e85a70d1bb3815",
+        "is_verified": false,
+        "line_number": 914
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "aafdc23870ecbcd3d557b6423a8982134e17927e",
+        "is_verified": false,
+        "line_number": 942
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 951
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "c026c2511a431f9e2cd443facb5bd9394757defd",
+        "is_verified": false,
+        "line_number": 959
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 966
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 978
+      }
+    ],
+    "backend/tests/unit/core/test_logging_sanitization.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "5561020ac01fee93a57def5a1d39bdb8954fcb47",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "400ec055d6b86f5fd1e3a6864dfe9f6a8035dd02",
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "f937639d254db532daad8ee8dcc6e16528116250",
+        "is_verified": false,
+        "line_number": 73
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "3cf281761cff86324c72f9771e39a62d729eb073",
+        "is_verified": false,
+        "line_number": 96
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 125
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 133
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
+        "is_verified": false,
+        "line_number": 140
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "a761ce3a45d97e41840a788495e85a70d1bb3815",
+        "is_verified": false,
+        "line_number": 147
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "e63a0ab2f8e7ecde486b42ebfec16d4434840af4",
+        "is_verified": false,
+        "line_number": 154
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "25d6ce68cb60679d781f2dce4c27f8aff4b723fd",
+        "is_verified": false,
+        "line_number": 161
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "76e1f98366934e087adb4ea26a45ca208e6ab340",
+        "is_verified": false,
+        "line_number": 168
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "d6fca828459d56fac6b34bb07e9e573538e58a26",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 193
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "364bdf2ed77a8544d3b711a03b69eeadcc63c9d7",
+        "is_verified": false,
+        "line_number": 310
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "720529e2bf3ac9442d4ee144bf840912831528d7",
+        "is_verified": false,
+        "line_number": 320
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
+        "is_verified": false,
+        "line_number": 500
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "745d0b2380e21353d526db47a87158f2065563ee",
+        "is_verified": false,
+        "line_number": 603
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "339ef090692579c473a218264c2ef7cd1327dd8b",
+        "is_verified": false,
+        "line_number": 605
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "17e7c34d5da1eef78f1f6f2671efec195adfb6ac",
+        "is_verified": false,
+        "line_number": 606
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "5f1ab34ad4b6fbd74db8b2a2dd6c5f66388cc4b1",
+        "is_verified": false,
+        "line_number": 637
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "d7da890000a70fb987eba7add0b302a8c4b6eeee",
+        "is_verified": false,
+        "line_number": 638
+      }
+    ],
+    "backend/tests/unit/core/test_middleware.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/core/test_middleware.py",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 295
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/core/test_middleware.py",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 309
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/core/test_middleware.py",
+        "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
+        "is_verified": false,
+        "line_number": 328
+      }
+    ],
+    "backend/tests/unit/core/test_url_validation.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_url_validation.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 291
+      }
+    ],
+    "backend/tests/unit/core/test_websocket_timeout.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/core/test_websocket_timeout.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "backend/tests/unit/routes/test_admin_routes.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/routes/test_admin_routes.py",
+        "hashed_secret": "a3e67861a6d3060155973f4d1dbfb06712f1ef1a",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/routes/test_admin_routes.py",
+        "hashed_secret": "8bc920da69bbf0db0452dc37ac397a810dd1b704",
+        "is_verified": false,
+        "line_number": 175
+      }
+    ],
+    "backend/tests/unit/routes/test_websocket_routes.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/routes/test_websocket_routes.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 21
+      }
+    ],
+    "backend/tests/unit/services/test_notification.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/services/test_notification.py",
+        "hashed_secret": "2e1fac07863a2f748ba5d68adc111823ba71f6f9",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
+    "backend/tests/unit/services/test_notification_webhook_ssrf.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/services/test_notification_webhook_ssrf.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 133
+      }
+    ],
+    "backend/tests/unit/test_benchmarks.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/test_benchmarks.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 358
+      }
+    ],
+    "backend/tests/unit/test_migrate_sqlite_postgres.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/test_migrate_sqlite_postgres.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 88
+      }
+    ],
+    "data/AGENTS.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "data/AGENTS.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 34
+      }
+    ],
+    "docker-compose.test.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.test.yml",
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "docs/LINEAR-GITHUB-INTEGRATION.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/LINEAR-GITHUB-INTEGRATION.md",
+        "hashed_secret": "5be4c3272edfad6114a3e4f0e31dd644c960700b",
+        "is_verified": false,
+        "line_number": 95
+      }
+    ],
+    "docs/LINEAR_SETUP_PROMPT.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/LINEAR_SETUP_PROMPT.md",
+        "hashed_secret": "577c05301430380c6daca0056d3f39d47adb7554",
+        "is_verified": false,
+        "line_number": 24
+      }
+    ],
+    "docs/METRICS_ENDPOINT_HARDENING.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/METRICS_ENDPOINT_HARDENING.md",
+        "hashed_secret": "a74d74619aca80255d605d6ae3e1607344921126",
+        "is_verified": false,
+        "line_number": 144
+      }
+    ],
+    "docs/RUNTIME_CONFIG.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/RUNTIME_CONFIG.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 170
+      }
+    ],
+    "docs/admin-guide/configuration.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/admin-guide/configuration.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 65
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/admin-guide/configuration.md",
+        "hashed_secret": "564e340cd48437d2dfe876ee154cc99dc4d0d137",
+        "is_verified": false,
+        "line_number": 69
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/admin-guide/configuration.md",
+        "hashed_secret": "21672328ab5c939c8a4324d118b264d9f34b0439",
+        "is_verified": false,
+        "line_number": 558
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/admin-guide/configuration.md",
+        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
+        "is_verified": false,
+        "line_number": 582
+      }
+    ],
+    "docs/admin-guide/security.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/admin-guide/security.md",
+        "hashed_secret": "7682bcd1378105f37fe6db8f2dca4105544a23cc",
+        "is_verified": false,
+        "line_number": 92
+      }
+    ],
+    "docs/admin-guide/troubleshooting.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/admin-guide/troubleshooting.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 189
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/admin-guide/troubleshooting.md",
+        "hashed_secret": "564e340cd48437d2dfe876ee154cc99dc4d0d137",
+        "is_verified": false,
+        "line_number": 192
+      }
+    ],
+    "docs/developer/data-model.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/developer/data-model.md",
+        "hashed_secret": "4b4cee89b354b993a64e0134e457cddc540a1833",
+        "is_verified": false,
+        "line_number": 1007
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/developer/data-model.md",
+        "hashed_secret": "5227a37d3bf602e316b4ee2903749ace643ec023",
+        "is_verified": false,
+        "line_number": 1008
+      }
+    ],
+    "docs/development/hooks.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/development/hooks.md",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 330
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/development/hooks.md",
+        "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
+        "is_verified": false,
+        "line_number": 353
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/development/hooks.md",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 415
+      }
+    ],
+    "docs/openapi.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/openapi.json",
+        "hashed_secret": "b6d882abaa2bcaec84e981b916a46043e80b39f0",
+        "is_verified": false,
+        "line_number": 1300
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/openapi.json",
+        "hashed_secret": "317481d6f1f675418bf892cfab9ef55e37265337",
+        "is_verified": false,
+        "line_number": 4634
+      }
+    ],
+    "docs/operator-hub.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/operator-hub.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 203
+      }
+    ],
+    "docs/operator/database.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/operator/database.md",
+        "hashed_secret": "c35bdb821a941808a150db95d0f934f449bbff17",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/operator/database.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/operator/database.md",
+        "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
+        "is_verified": false,
+        "line_number": 253
+      }
+    ],
+    "docs/plans/2026-01-02-interactive-setup-script-implementation.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/plans/2026-01-02-interactive-setup-script-implementation.md",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 32
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/plans/2026-01-02-interactive-setup-script-implementation.md",
+        "hashed_secret": "1c58bd92003bbaa0538e249fff6ee19a270dec5f",
+        "is_verified": false,
+        "line_number": 559
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/plans/2026-01-02-interactive-setup-script-implementation.md",
+        "hashed_secret": "3d1eadecab69da6d5cbe7f0c5fea8e5b3fd984b7",
+        "is_verified": false,
+        "line_number": 560
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/plans/2026-01-02-interactive-setup-script-implementation.md",
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "is_verified": false,
+        "line_number": 870
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/plans/2026-01-02-interactive-setup-script-implementation.md",
+        "hashed_secret": "5f8e36de9e9d93f05bae00cafa6b6f97355a4add",
+        "is_verified": false,
+        "line_number": 871
+      }
+    ],
+    "docs/reference/config/env-reference.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/reference/config/env-reference.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 36
+      }
+    ],
+    "docs/reference/troubleshooting/database-issues.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/reference/troubleshooting/database-issues.md",
+        "hashed_secret": "564e340cd48437d2dfe876ee154cc99dc4d0d137",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/reference/troubleshooting/database-issues.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/reference/troubleshooting/database-issues.md",
+        "hashed_secret": "564e340cd48437d2dfe876ee154cc99dc4d0d137",
+        "is_verified": false,
+        "line_number": 137
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/reference/troubleshooting/database-issues.md",
+        "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
+        "is_verified": false,
+        "line_number": 333
+      }
+    ],
+    "mutants/backend/AGENTS.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/AGENTS.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 352
+      }
+    ],
+    "mutants/backend/alembic.ini": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/alembic.ini",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 87
+      }
+    ],
+    "mutants/backend/alembic/AGENTS.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/alembic/AGENTS.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 84
+      }
+    ],
+    "mutants/backend/alembic/env.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/alembic/env.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 33
+      }
+    ],
+    "mutants/backend/core/AGENTS.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/core/AGENTS.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 178
+      }
+    ],
+    "mutants/backend/core/README.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/core/README.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/core/README.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 139
+      }
+    ],
+    "mutants/backend/core/logging.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/core/logging.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/core/logging.py",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/core/logging.py",
+        "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
+        "is_verified": false,
+        "line_number": 73
+      }
+    ],
+    "mutants/backend/data/AGENTS.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/data/AGENTS.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 82
+      }
+    ],
+    "mutants/backend/tests/conftest.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/conftest.py",
+        "hashed_secret": "b5816d1465d319d1b4d29cfbc06e1f9c85dae86d",
+        "is_verified": false,
+        "line_number": 113
+      }
+    ],
+    "mutants/backend/tests/integration/conftest.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/integration/conftest.py",
+        "hashed_secret": "b5816d1465d319d1b4d29cfbc06e1f9c85dae86d",
+        "is_verified": false,
+        "line_number": 60
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/integration/conftest.py",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 116
+      }
+    ],
+    "mutants/backend/tests/integration/test_admin_api.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/integration/test_admin_api.py",
+        "hashed_secret": "19a4d55f26cb700d093f88a74673e357130062fb",
+        "is_verified": false,
+        "line_number": 122
+      }
+    ],
+    "mutants/backend/tests/integration/test_alembic_migrations.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/integration/test_alembic_migrations.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 65
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/integration/test_alembic_migrations.py",
+        "hashed_secret": "5561020ac01fee93a57def5a1d39bdb8954fcb47",
+        "is_verified": false,
+        "line_number": 90
+      }
+    ],
+    "mutants/backend/tests/integration/test_api_error_scenarios.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/integration/test_api_error_scenarios.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 769
+      }
+    ],
+    "mutants/backend/tests/integration/test_api_errors.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/integration/test_api_errors.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 898
+      }
+    ],
+    "mutants/backend/tests/integration/test_circuit_breaker.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/integration/test_circuit_breaker.py",
+        "hashed_secret": "b5816d1465d319d1b4d29cfbc06e1f9c85dae86d",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
+    "mutants/backend/tests/integration/test_http_error_codes.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/integration/test_http_error_codes.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 253
+      }
+    ],
+    "mutants/backend/tests/integration/test_media_api.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/integration/test_media_api.py",
+        "hashed_secret": "b5816d1465d319d1b4d29cfbc06e1f9c85dae86d",
+        "is_verified": false,
+        "line_number": 147
+      }
+    ],
+    "mutants/backend/tests/integration/test_media_security.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/integration/test_media_security.py",
+        "hashed_secret": "b5816d1465d319d1b4d29cfbc06e1f9c85dae86d",
+        "is_verified": false,
+        "line_number": 153
+      }
+    ],
+    "mutants/backend/tests/integration/test_notification_api.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/integration/test_notification_api.py",
+        "hashed_secret": "1544cdc8fee8460cc268b2c57054f4ec8a83e210",
+        "is_verified": false,
+        "line_number": 66
+      }
+    ],
+    "mutants/backend/tests/integration/test_websocket.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/integration/test_websocket.py",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 625
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/integration/test_websocket.py",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 873
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/integration/test_websocket.py",
+        "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
+        "is_verified": false,
+        "line_number": 917
+      }
+    ],
+    "mutants/backend/tests/integration/test_websocket_auth.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/integration/test_websocket_auth.py",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/integration/test_websocket_auth.py",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 166
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/integration/test_websocket_auth.py",
+        "hashed_secret": "6b1e40e9988ac99f3ebee3757d2f9d95bb4d3608",
+        "is_verified": false,
+        "line_number": 809
+      }
+    ],
+    "mutants/backend/tests/unit/api/routes/test_ai_audit.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/api/routes/test_ai_audit.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "mutants/backend/tests/unit/api/routes/test_dlq_api.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/api/routes/test_dlq_api.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
+    "mutants/backend/tests/unit/api/routes/test_events_export.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/api/routes/test_events_export.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 606
+      }
+    ],
+    "mutants/backend/tests/unit/api/routes/test_prompt_management.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/api/routes/test_prompt_management.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
+    "mutants/backend/tests/unit/core/test_auth_middleware.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_auth_middleware.py",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_auth_middleware.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 32
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_auth_middleware.py",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 81
+      }
+    ],
+    "mutants/backend/tests/unit/core/test_config.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_config.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_config.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 133
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_config.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 710
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_config.py",
+        "hashed_secret": "b02c6bf2b2b576d253f5c9db76999eebc4f00ad2",
+        "is_verified": false,
+        "line_number": 864
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_config.py",
+        "hashed_secret": "25e0a2994071f26ff23bdacd481749eb5ef602e6",
+        "is_verified": false,
+        "line_number": 875
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_config.py",
+        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
+        "is_verified": false,
+        "line_number": 886
+      }
+    ],
+    "mutants/backend/tests/unit/core/test_database_pool.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_database_pool.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 64
+      }
+    ],
+    "mutants/backend/tests/unit/core/test_logging.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 294
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 900
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
+        "is_verified": false,
+        "line_number": 907
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "a761ce3a45d97e41840a788495e85a70d1bb3815",
+        "is_verified": false,
+        "line_number": 914
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "aafdc23870ecbcd3d557b6423a8982134e17927e",
+        "is_verified": false,
+        "line_number": 942
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 951
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "c026c2511a431f9e2cd443facb5bd9394757defd",
+        "is_verified": false,
+        "line_number": 959
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 966
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 978
+      }
+    ],
+    "mutants/backend/tests/unit/core/test_logging_sanitization.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "5561020ac01fee93a57def5a1d39bdb8954fcb47",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "400ec055d6b86f5fd1e3a6864dfe9f6a8035dd02",
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "f937639d254db532daad8ee8dcc6e16528116250",
+        "is_verified": false,
+        "line_number": 73
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "3cf281761cff86324c72f9771e39a62d729eb073",
+        "is_verified": false,
+        "line_number": 96
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 125
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 133
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
+        "is_verified": false,
+        "line_number": 140
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "a761ce3a45d97e41840a788495e85a70d1bb3815",
+        "is_verified": false,
+        "line_number": 147
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "e63a0ab2f8e7ecde486b42ebfec16d4434840af4",
+        "is_verified": false,
+        "line_number": 154
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "25d6ce68cb60679d781f2dce4c27f8aff4b723fd",
+        "is_verified": false,
+        "line_number": 161
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "76e1f98366934e087adb4ea26a45ca208e6ab340",
+        "is_verified": false,
+        "line_number": 168
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "d6fca828459d56fac6b34bb07e9e573538e58a26",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 193
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "364bdf2ed77a8544d3b711a03b69eeadcc63c9d7",
+        "is_verified": false,
+        "line_number": 310
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "720529e2bf3ac9442d4ee144bf840912831528d7",
+        "is_verified": false,
+        "line_number": 320
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
+        "is_verified": false,
+        "line_number": 500
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "745d0b2380e21353d526db47a87158f2065563ee",
+        "is_verified": false,
+        "line_number": 603
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "339ef090692579c473a218264c2ef7cd1327dd8b",
+        "is_verified": false,
+        "line_number": 605
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "17e7c34d5da1eef78f1f6f2671efec195adfb6ac",
+        "is_verified": false,
+        "line_number": 606
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "5f1ab34ad4b6fbd74db8b2a2dd6c5f66388cc4b1",
+        "is_verified": false,
+        "line_number": 637
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_logging_sanitization.py",
+        "hashed_secret": "d7da890000a70fb987eba7add0b302a8c4b6eeee",
+        "is_verified": false,
+        "line_number": 638
+      }
+    ],
+    "mutants/backend/tests/unit/core/test_middleware.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_middleware.py",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 295
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_middleware.py",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 309
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_middleware.py",
+        "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
+        "is_verified": false,
+        "line_number": 328
+      }
+    ],
+    "mutants/backend/tests/unit/core/test_rate_limit.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_rate_limit.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 1151
+      }
+    ],
+    "mutants/backend/tests/unit/core/test_redis.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_redis.py",
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_verified": false,
+        "line_number": 1770
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_redis.py",
+        "hashed_secret": "def98c674bb8cdd4b7d00e24e5ddfbc4ac12752d",
+        "is_verified": false,
+        "line_number": 1788
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_redis.py",
+        "hashed_secret": "983f31f39e482f5d42518f8b2e466e985816010c",
+        "is_verified": false,
+        "line_number": 1818
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/core/test_redis.py",
+        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
+        "is_verified": false,
+        "line_number": 1881
+      }
+    ],
+    "mutants/backend/tests/unit/core/test_url_validation.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_url_validation.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 291
+      }
+    ],
+    "mutants/backend/tests/unit/core/test_websocket_timeout.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/core/test_websocket_timeout.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "mutants/backend/tests/unit/routes/test_admin_routes.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/routes/test_admin_routes.py",
+        "hashed_secret": "a3e67861a6d3060155973f4d1dbfb06712f1ef1a",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/routes/test_admin_routes.py",
+        "hashed_secret": "8bc920da69bbf0db0452dc37ac397a810dd1b704",
+        "is_verified": false,
+        "line_number": 175
+      }
+    ],
+    "mutants/backend/tests/unit/routes/test_system_routes.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/routes/test_system_routes.py",
+        "hashed_secret": "3bee216ebc256d692260fc3adc765050508fef5e",
+        "is_verified": false,
+        "line_number": 3007
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/routes/test_system_routes.py",
+        "hashed_secret": "4c37d0e3ed4f0e4f8bf14ff0561723aec7a5cee6",
+        "is_verified": false,
+        "line_number": 3022
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/routes/test_system_routes.py",
+        "hashed_secret": "42b65d1f86f5d0276dc36f2c625f864f24ed31d2",
+        "is_verified": false,
+        "line_number": 3034
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/routes/test_system_routes.py",
+        "hashed_secret": "7f83ec63ff6dd9a5445ade80ec7f2a83ae652f8b",
+        "is_verified": false,
+        "line_number": 3035
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/routes/test_system_routes.py",
+        "hashed_secret": "bf03592d1115fceacc9a628906e3c761aa5c7591",
+        "is_verified": false,
+        "line_number": 3036
+      }
+    ],
+    "mutants/backend/tests/unit/routes/test_websocket_routes.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/routes/test_websocket_routes.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 21
+      }
+    ],
+    "mutants/backend/tests/unit/services/test_cleanup_service.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/services/test_cleanup_service.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 37
+      }
+    ],
+    "mutants/backend/tests/unit/services/test_notification.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/backend/tests/unit/services/test_notification.py",
+        "hashed_secret": "2e1fac07863a2f748ba5d68adc111823ba71f6f9",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
+    "mutants/backend/tests/unit/services/test_notification_webhook_ssrf.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/services/test_notification_webhook_ssrf.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 133
+      }
+    ],
+    "mutants/backend/tests/unit/test_benchmarks.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/test_benchmarks.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 358
+      }
+    ],
+    "mutants/backend/tests/unit/test_migrate_sqlite_postgres.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "mutants/backend/tests/unit/test_migrate_sqlite_postgres.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 88
+      }
+    ],
+    "mutants/tests/test_setup.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/tests/test_setup.py",
+        "hashed_secret": "1c58bd92003bbaa0538e249fff6ee19a270dec5f",
+        "is_verified": false,
+        "line_number": 70
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/tests/test_setup.py",
+        "hashed_secret": "3d1eadecab69da6d5cbe7f0c5fea8e5b3fd984b7",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/tests/test_setup.py",
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "mutants/tests/test_setup.py",
+        "hashed_secret": "5f8e36de9e9d93f05bae00cafa6b6f97355a4add",
+        "is_verified": false,
+        "line_number": 208
+      }
+    ],
+    "scripts/README.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/README.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 254
+      }
+    ],
+    "scripts/cleanup_orphaned_test_cameras.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/cleanup_orphaned_test_cameras.py",
+        "hashed_secret": "b5816d1465d319d1b4d29cfbc06e1f9c85dae86d",
+        "is_verified": false,
+        "line_number": 200
+      }
+    ],
+    "scripts/db-migrate.sh": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/db-migrate.sh",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "scripts/migrate-sqlite-to-postgres.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/migrate-sqlite-to-postgres.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/migrate-sqlite-to-postgres.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 45
+      }
+    ],
+    "scripts/migrate_beads_to_linear.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts/migrate_beads_to_linear.py",
+        "hashed_secret": "5be4c3272edfad6114a3e4f0e31dd644c960700b",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "scripts/test-in-container.sh": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/test-in-container.sh",
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "tests/test_setup.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_setup.py",
+        "hashed_secret": "1c58bd92003bbaa0538e249fff6ee19a270dec5f",
+        "is_verified": false,
+        "line_number": 70
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_setup.py",
+        "hashed_secret": "3d1eadecab69da6d5cbe7f0c5fea8e5b3fd984b7",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_setup.py",
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_setup.py",
+        "hashed_secret": "5f8e36de9e9d93f05bae00cafa6b6f97355a4add",
+        "is_verified": false,
+        "line_number": 208
+      }
+    ],
+    "vsftpd/README.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "vsftpd/README.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 73
+      }
+    ]
+  },
+  "generated_at": "2026-01-09T18:07:49Z"
+}

--- a/frontend/src/types/generated/websocket.ts
+++ b/frontend/src/types/generated/websocket.ts
@@ -10,7 +10,7 @@
  * Source schemas:
  *   backend/api/schemas/websocket.py
  *
- * Generated at: 2026-01-09T14:46:12Z
+ * Generated at: 2026-01-09T20:31:20Z
  *
  * Note: WebSocket messages are not covered by OpenAPI, so we generate these
  * types separately to ensure frontend/backend type synchronization.


### PR DESCRIPTION
## Summary
- Add pre-commit hook that auto-regenerates `docs/openapi.json` when backend API/models/schemas change
- Regenerate openapi.json to sync with current backend state
- Update WebSocket types
- Restore `.secrets.baseline` after rebase conflict

## Why
Multiple PRs are failing the "API Types Contract Check" in CI because `docs/openapi.json` is out of sync. This fix:
1. Regenerates the spec to fix current failures
2. Adds a pre-commit hook to prevent future drift

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI passes API Types Contract Check
- [ ] Other PRs can rebase on main after this merges

🤖 Generated with [Claude Code](https://claude.ai/code)