### PR TITLE
fix(ci): update oasdiff to 1.11.4 for OpenAPI 3.1 support

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Install oasdiff
         run: |
           # Install oasdiff for OpenAPI schema comparison
-          OASDIFF_VERSION="1.10.25"
+          # Using latest version with OpenAPI 3.1 support (numeric exclusiveMinimum)
+          OASDIFF_VERSION="1.11.4"
           DOWNLOAD_URL="https://github.com/Tufin/oasdiff/releases/download/v${OASDIFF_VERSION}/oasdiff_${OASDIFF_VERSION}_linux_amd64.tar.gz"
 
           # Download with retry and error checking


### PR DESCRIPTION
## Summary

Update oasdiff version from 1.10.25 to 1.11.4 to fix API Contract Testing workflow failures.

## Problem

The API Contract Testing workflow was failing on all PRs with:
```
Error: json: cannot unmarshal number into field Schema.exclusiveMinimum of type bool
```

This is because oasdiff 1.10.25 doesn't support OpenAPI 3.1's numeric `exclusiveMinimum` format (JSON Schema draft 2020-12).

## Solution

Update oasdiff to version 1.11.4 which includes OpenAPI 3.1 support via the updated kin-openapi library (0.132.0).

## Testing

- This is a CI configuration change only
- The new oasdiff version should be able to parse both OpenAPI 3.0 and 3.1 specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)