### PR TITLE
fix(ci): prevent PR comment failures from blocking API contract tests

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -190,6 +190,7 @@ jobs:
 
       - name: Comment PR with contract test results
         if: always()
+        continue-on-error: true # Don't fail job if commenting fails (permissions may be limited)
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |


### PR DESCRIPTION
## Summary

Prevent permission errors from failing the API Contract Testing workflow.

## Problem

The API Contract Testing workflow was failing when it couldn't post comments to PRs (403 permission errors). This happened because the workflow uses `pull_request` trigger which has limited write permissions for external PRs.

The actual contract test was PASSING (no breaking changes detected), but the workflow failed because the comment step threw an error.

## Solution

Added `continue-on-error: true` to the comment step so that permission errors don't fail the entire workflow when the actual contract test passes.

## Impact

This will unblock all currently failing PRs that are stuck due to this permission issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)