### PR TITLE
feat: register RequestLoggingMiddleware and RequestRecorderMiddleware (NEM-1963, NEM-1964)

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1192,6 +1192,15 @@ class Settings(BaseSettings):
         "Files can be analyzed with 'snakeviz <file>.prof' or converted to flamegraphs.",
     )
 
+    # Request logging settings (NEM-1963)
+    # Enable structured request/response logging for observability
+    request_logging_enabled: bool = Field(
+        default=True,
+        description="Enable structured request/response logging middleware. "
+        "When enabled, HTTP requests are logged with timing, status codes, and correlation IDs. "
+        "Health check and metrics endpoints are excluded by default to reduce noise.",
+    )
+
     # Request recording settings (NEM-1646)
     # Enable request recording for debugging production issues
     request_recording_enabled: bool = Field(


### PR DESCRIPTION
## Summary

- Register `RequestLoggingMiddleware` in main.py - structured HTTP request/response logging with timing, status codes, and correlation IDs (enabled by default)
- Register `RequestRecorderMiddleware` in main.py - request recording for debugging production issues (disabled by default)
- Add `request_logging_enabled` configuration setting to control logging middleware

## Changes

| File | Change |
|------|--------|
| `backend/core/config.py` | Added `request_logging_enabled` setting (default: True) |
| `backend/main.py` | Import and conditionally register both middleware |

## Middleware Order

```
RequestTimingMiddleware (existing)
RequestLoggingMiddleware <- NEW (NEM-1963)
RequestRecorderMiddleware <- NEW (NEM-1964)
DeprecationMiddleware (existing)
```

## Configuration

| Setting | Default | Purpose |
|---------|---------|---------|
| `request_logging_enabled` | `True` | Enable structured request logging |
| `request_recording_enabled` | `False` | Enable request recording (debugging) |

## Test plan

- [x] Backend unit tests pass
- [x] mypy type checking passes
- [x] Pre-commit hooks pass
- [ ] CI validates full test suite

Closes NEM-1963, NEM-1964 (part of Epic NEM-1941)

🤖 Generated with [Claude Code](https://claude.ai/code)