### PR TITLE
feat: implement event ordering & idempotency (NEM-1999)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from backend.api.middleware import (
     DeprecationConfig,
     DeprecationLoggerMiddleware,
     DeprecationMiddleware,
+    IdempotencyMiddleware,
     RequestLoggingMiddleware,
     RequestRecorderMiddleware,
     RequestTimingMiddleware,
@@ -853,6 +854,12 @@ app.add_middleware(SecurityHeadersMiddleware, hsts_preload=get_settings().hsts_p
 # Add body size limit middleware to prevent DoS attacks (NEM-1614)
 # Default: 10MB limit for request bodies
 app.add_middleware(BodySizeLimitMiddleware, max_body_size=10 * 1024 * 1024)
+
+# Add idempotency middleware for mutation endpoints (NEM-1999)
+# Caches responses by Idempotency-Key header to prevent duplicate operations
+# Must be after body limit (to validate body first) and before auth (to cache auth'd responses)
+if get_settings().idempotency_enabled:
+    app.add_middleware(IdempotencyMiddleware)
 
 # Register global exception handlers for consistent error responses
 register_exception_handlers(app)

--- a/frontend/src/components/events/EventTimeline.test.tsx
+++ b/frontend/src/components/events/EventTimeline.test.tsx
@@ -182,6 +182,13 @@ describe('EventTimeline', () => {
       isConnected: true,
       latestEvent: mockWsEvents[0],
       clearEvents: vi.fn(),
+      sequenceStats: {
+        processedCount: 0,
+        duplicateCount: 0,
+        resyncCount: 0,
+        outOfOrderCount: 0,
+        currentBufferSize: 0,
+      },
     });
   });
 
@@ -230,6 +237,13 @@ describe('EventTimeline', () => {
         isConnected: false,
         latestEvent: null,
         clearEvents: vi.fn(),
+        sequenceStats: {
+          processedCount: 0,
+          duplicateCount: 0,
+          resyncCount: 0,
+          outOfOrderCount: 0,
+          currentBufferSize: 0,
+        },
       });
 
       renderWithProviders(<EventTimeline />);

--- a/frontend/src/hooks/__mocks__/useEventStream.ts
+++ b/frontend/src/hooks/__mocks__/useEventStream.ts
@@ -26,6 +26,7 @@
 import { vi } from 'vitest';
 
 import type { RiskLevel } from '../../types/websocket';
+import type { SequenceStatistics } from '../sequenceValidator';
 import type { UseEventStreamReturn, SecurityEvent } from '../useEventStream';
 
 // =============================================================================
@@ -68,7 +69,20 @@ export interface MockEventStreamOptions {
   events?: SecurityEvent[];
   /** Whether the WebSocket is connected. Default: false */
   isConnected?: boolean;
+  /** Sequence validation statistics. Default: empty stats */
+  sequenceStats?: SequenceStatistics;
 }
+
+/**
+ * Default empty sequence statistics for mocks.
+ */
+const DEFAULT_SEQUENCE_STATS: SequenceStatistics = {
+  processedCount: 0,
+  duplicateCount: 0,
+  resyncCount: 0,
+  outOfOrderCount: 0,
+  currentBufferSize: 0,
+};
 
 /**
  * Mock return type for useEventStream hook.
@@ -257,13 +271,14 @@ export function createMockEventList(count: number = 5): SecurityEvent[] {
  * ```
  */
 export function createMockEventStream(options: MockEventStreamOptions = {}): MockEventStreamReturn {
-  const { events = [], isConnected = false } = options;
+  const { events = [], isConnected = false, sequenceStats = DEFAULT_SEQUENCE_STATS } = options;
 
   return {
     events,
     isConnected,
     latestEvent: events.length > 0 ? events[0] : null,
     clearEvents: vi.fn(),
+    sequenceStats,
   };
 }
 
@@ -360,6 +375,7 @@ export function addEventToStream(
     ...mockReturn,
     events: newEvents,
     latestEvent: event,
+    sequenceStats: mockReturn.sequenceStats,
   };
 }
 


### PR DESCRIPTION
## Summary

- Register IdempotencyMiddleware in backend for mutation endpoints (POST/PUT/DELETE)
- Integrate SequenceValidator into useEventStream hook for event ordering
- Add buffer-and-reorder strategy for out-of-order WebSocket events
- Implement resync request capability when large gaps detected
- LRU cache for dedup already existed (NEM-2020)

## Acceptance Criteria

- [x] Idempotency-Key header support on POST/PUT/DELETE (32 tests)
- [x] Sequence number validation in frontend (76 tests)
- [x] Bounded LRU cache for dedup (max 10k entries) - already existed
- [x] Out-of-order event handling strategy (buffer & reorder)
- [ ] Integration tests for idempotency (unit tests exist)

## Test Results

| Suite | Result |
|-------|--------|
| Backend Unit Tests | 13,478 passed |
| Frontend Tests | 7,551 passed |

## Changes

| File | Change |
|------|--------|
| `backend/main.py` | Register IdempotencyMiddleware |
| `frontend/src/hooks/useEventStream.ts` | Integrate SequenceValidator |
| `frontend/src/hooks/useEventStream.test.ts` | Add sequence validation tests |
| `frontend/src/hooks/__mocks__/useEventStream.ts` | Add sequenceStats mock |
| `frontend/src/components/events/EventTimeline.test.tsx` | Update mock returns |

## Test plan

- [x] Backend unit tests pass (13,478)
- [x] Frontend unit tests pass (7,551)
- [x] TypeScript type checking passes
- [x] ESLint passes
- [ ] E2E tests (pre-existing accessibility failures unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)