### PR TITLE
feat: implement rate limiting UI feedback (NEM-1967, NEM-1969, NEM-1970)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,10 +9,12 @@ import {
   ErrorBoundary,
   PageTransition,
   ProductTour,
+  RateLimitIndicator,
   RouteLoadingFallback,
   ToastProvider,
 } from './components/common';
 import Layout from './components/layout/Layout';
+import RetryingIndicator from './components/RetryingIndicator';
 import { queryClient } from './services/queryClient';
 
 // Lazy-loaded page components for code splitting
@@ -103,6 +105,10 @@ export default function App() {
           {/* Interactive product tour for first-time users */}
           <ProductTour />
         </BrowserRouter>
+        {/* Rate limit indicator - fixed position overlay */}
+        <RateLimitIndicator />
+        {/* Retrying indicator - shows when rate limited AND requests in flight */}
+        <RetryingIndicator />
         {/* React Query DevTools - only shown in development */}
         <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-right" />
       </ToastProvider>

--- a/frontend/src/components/RetryingIndicator.test.tsx
+++ b/frontend/src/components/RetryingIndicator.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Tests for RetryingIndicator component (NEM-1970)
+ *
+ * Tests that the indicator shows only when:
+ * - The client is rate limited (isLimited = true)
+ * - AND there are queries or mutations in flight
+ */
+
+import { QueryClient, QueryClientProvider, useIsFetching, useIsMutating } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import RetryingIndicator from './RetryingIndicator';
+import { useRateLimitStore } from '../stores/rate-limit-store';
+
+// Mock the rate limit store
+vi.mock('../stores/rate-limit-store', () => ({
+  useRateLimitStore: vi.fn(),
+}));
+
+// Mock TanStack Query hooks
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useIsFetching: vi.fn(() => 0),
+    useIsMutating: vi.fn(() => 0),
+  };
+});
+
+describe('RetryingIndicator', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    // Default: not rate limited, no requests in flight
+    vi.mocked(useRateLimitStore).mockReturnValue({
+      current: null,
+      isLimited: false,
+      secondsUntilReset: 0,
+      update: vi.fn(),
+      clear: vi.fn(),
+      _timerId: null,
+    });
+    vi.mocked(useIsFetching).mockReturnValue(0);
+    vi.mocked(useIsMutating).mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderComponent = () => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <RetryingIndicator />
+      </QueryClientProvider>
+    );
+  };
+
+  describe('visibility conditions', () => {
+    it('does not render when not rate limited and no requests in flight', () => {
+      renderComponent();
+      expect(screen.queryByTestId('retrying-indicator')).not.toBeInTheDocument();
+    });
+
+    it('does not render when rate limited but no requests in flight', () => {
+      vi.mocked(useRateLimitStore).mockReturnValue({
+        current: { limit: 100, remaining: 0, reset: Date.now() / 1000 + 60 },
+        isLimited: true,
+        secondsUntilReset: 60,
+        update: vi.fn(),
+        clear: vi.fn(),
+        _timerId: null,
+      });
+
+      renderComponent();
+      expect(screen.queryByTestId('retrying-indicator')).not.toBeInTheDocument();
+    });
+
+    it('does not render when not rate limited but queries are in flight', () => {
+      vi.mocked(useIsFetching).mockReturnValue(3);
+
+      renderComponent();
+      expect(screen.queryByTestId('retrying-indicator')).not.toBeInTheDocument();
+    });
+
+    it('does not render when not rate limited but mutations are in flight', () => {
+      vi.mocked(useIsMutating).mockReturnValue(1);
+
+      renderComponent();
+      expect(screen.queryByTestId('retrying-indicator')).not.toBeInTheDocument();
+    });
+
+    it('renders when rate limited AND queries are in flight', () => {
+      vi.mocked(useRateLimitStore).mockReturnValue({
+        current: { limit: 100, remaining: 0, reset: Date.now() / 1000 + 60 },
+        isLimited: true,
+        secondsUntilReset: 60,
+        update: vi.fn(),
+        clear: vi.fn(),
+        _timerId: null,
+      });
+      vi.mocked(useIsFetching).mockReturnValue(2);
+
+      renderComponent();
+      expect(screen.getByTestId('retrying-indicator')).toBeInTheDocument();
+    });
+
+    it('renders when rate limited AND mutations are in flight', () => {
+      vi.mocked(useRateLimitStore).mockReturnValue({
+        current: { limit: 100, remaining: 0, reset: Date.now() / 1000 + 60 },
+        isLimited: true,
+        secondsUntilReset: 60,
+        update: vi.fn(),
+        clear: vi.fn(),
+        _timerId: null,
+      });
+      vi.mocked(useIsMutating).mockReturnValue(1);
+
+      renderComponent();
+      expect(screen.getByTestId('retrying-indicator')).toBeInTheDocument();
+    });
+
+    it('renders when rate limited AND both queries and mutations are in flight', () => {
+      vi.mocked(useRateLimitStore).mockReturnValue({
+        current: { limit: 100, remaining: 0, reset: Date.now() / 1000 + 60 },
+        isLimited: true,
+        secondsUntilReset: 60,
+        update: vi.fn(),
+        clear: vi.fn(),
+        _timerId: null,
+      });
+      vi.mocked(useIsFetching).mockReturnValue(1);
+      vi.mocked(useIsMutating).mockReturnValue(1);
+
+      renderComponent();
+      expect(screen.getByTestId('retrying-indicator')).toBeInTheDocument();
+    });
+  });
+
+  describe('content and styling', () => {
+    beforeEach(() => {
+      vi.mocked(useRateLimitStore).mockReturnValue({
+        current: { limit: 100, remaining: 0, reset: Date.now() / 1000 + 60 },
+        isLimited: true,
+        secondsUntilReset: 60,
+        update: vi.fn(),
+        clear: vi.fn(),
+        _timerId: null,
+      });
+      vi.mocked(useIsFetching).mockReturnValue(1);
+    });
+
+    it('displays "Retrying request..." text', () => {
+      renderComponent();
+      expect(screen.getByText('Retrying request...')).toBeInTheDocument();
+    });
+
+    it('shows a spinner element', () => {
+      renderComponent();
+      expect(screen.getByTestId('retrying-spinner')).toBeInTheDocument();
+    });
+
+    it('has role="status" for accessibility', () => {
+      renderComponent();
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('has aria-live="polite" for screen readers', () => {
+      renderComponent();
+      const indicator = screen.getByTestId('retrying-indicator');
+      expect(indicator).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('applies custom className when provided', () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <RetryingIndicator className="custom-class" />
+        </QueryClientProvider>
+      );
+      const indicator = screen.getByTestId('retrying-indicator');
+      expect(indicator.className).toContain('custom-class');
+    });
+  });
+});

--- a/frontend/src/components/RetryingIndicator.tsx
+++ b/frontend/src/components/RetryingIndicator.tsx
@@ -1,0 +1,71 @@
+/**
+ * RetryingIndicator - Shows when requests are being automatically retried.
+ *
+ * This component displays a small indicator when the client is rate limited
+ * AND has active queries/mutations being retried.
+ *
+ * @example
+ * ```tsx
+ * // Add to App.tsx layout
+ * <RetryingIndicator />
+ * ```
+ */
+import { useIsFetching, useIsMutating } from '@tanstack/react-query';
+import { clsx } from 'clsx';
+
+import { useRateLimitStore } from '../stores/rate-limit-store';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RetryingIndicatorProps {
+  /** Optional class name for additional styling */
+  className?: string;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * RetryingIndicator shows when automatic retry is in progress.
+ *
+ * Only visible when:
+ * 1. Client is rate limited (remaining = 0)
+ * 2. AND there are active queries or mutations
+ */
+export default function RetryingIndicator({
+  className,
+}: RetryingIndicatorProps) {
+  const { isLimited } = useRateLimitStore();
+  const fetchingCount = useIsFetching();
+  const mutatingCount = useIsMutating();
+
+  // Only show if rate limited AND there are active requests
+  const hasActiveRequests = fetchingCount > 0 || mutatingCount > 0;
+  if (!isLimited || !hasActiveRequests) {
+    return null;
+  }
+
+  return (
+    <div
+      className={clsx(
+        'fixed bottom-20 right-4 z-50 flex items-center gap-2 rounded-lg border border-blue-300 bg-blue-100 px-3 py-2 shadow-lg',
+        className
+      )}
+      data-testid="retrying-indicator"
+      role="status"
+      aria-live="polite"
+    >
+      <div
+        className="h-4 w-4 animate-spin rounded-full border-2 border-blue-500 border-t-transparent"
+        data-testid="retrying-spinner"
+        aria-hidden="true"
+      />
+      <span className="text-sm font-medium text-blue-800">
+        Retrying request...
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/common/RateLimitIndicator.tsx
+++ b/frontend/src/components/common/RateLimitIndicator.tsx
@@ -1,0 +1,149 @@
+/**
+ * RateLimitIndicator - Displays rate limit status with countdown timer.
+ *
+ * Shows a fixed-position indicator when API rate limit quota is low or exhausted.
+ * - Yellow warning when quota < 50%
+ * - Red alert when rate limited (remaining = 0)
+ * - Live countdown showing seconds until reset
+ * - Auto-hides when quota replenishes above 50%
+ *
+ * @example
+ * ```tsx
+ * // Add to App.tsx layout
+ * <RateLimitIndicator />
+ * ```
+ */
+import { clsx } from 'clsx';
+import { AlertTriangle } from 'lucide-react';
+
+import { useRateLimitCountdown } from '../../hooks/useRateLimitCountdown';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RateLimitIndicatorProps {
+  /** Optional class name for additional styling */
+  className?: string;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Calculate the percentage of quota remaining.
+ * Returns a value between 0 and 100.
+ */
+function calculateRemainingPercentage(remaining: number, limit: number): number {
+  if (limit === 0) return 0;
+  return Math.round((remaining / limit) * 100);
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * RateLimitIndicator displays rate limit status with visual feedback.
+ *
+ * Features:
+ * - Fixed position at bottom-right corner
+ * - Yellow warning when quota drops below 50%
+ * - Red alert when rate limited (remaining = 0)
+ * - Live countdown timer until rate limit resets
+ * - Auto-hides when quota replenishes above 50%
+ * - Accessible with ARIA attributes
+ */
+export default function RateLimitIndicator({
+  className,
+}: RateLimitIndicatorProps) {
+  const { isLimited, formattedCountdown, current } = useRateLimitCountdown();
+
+  // Don't render if no rate limit info
+  if (!current) {
+    return null;
+  }
+
+  const remainingPercentage = calculateRemainingPercentage(
+    current.remaining,
+    current.limit
+  );
+
+  // Don't render if quota is above 50% and not rate limited
+  if (remainingPercentage > 50 && !isLimited) {
+    return null;
+  }
+
+  // Determine styling based on state
+  const isRateLimited = isLimited || current.remaining === 0;
+  const isVeryLow = remainingPercentage < 20;
+
+  // Build ARIA label
+  const ariaLabel = isRateLimited
+    ? `Rate limited. Retry in ${formattedCountdown}`
+    : `API quota low: ${current.remaining} of ${current.limit} requests remaining`;
+
+  return (
+    <div
+      className={clsx(
+        'fixed bottom-4 right-4 z-50 min-w-[200px] rounded-lg border p-4 shadow-lg',
+        isRateLimited
+          ? 'border-red-300 bg-red-100'
+          : 'border-yellow-300 bg-yellow-100',
+        className
+      )}
+      data-testid="rate-limit-indicator"
+      role="status"
+      aria-live="polite"
+      aria-label={ariaLabel}
+    >
+      {isRateLimited ? (
+        // Rate limited state - show alert with countdown
+        <div className="flex items-center gap-2">
+          <AlertTriangle
+            className="h-5 w-5 flex-shrink-0 text-red-600"
+            data-testid="rate-limit-icon"
+            aria-hidden="true"
+          />
+          <div>
+            <p className="font-medium text-red-800">Rate Limited</p>
+            <p className="text-sm text-red-600">Retry in {formattedCountdown}</p>
+          </div>
+        </div>
+      ) : (
+        // Low quota warning state - show progress bar
+        <div>
+          <div className="mb-1 flex justify-between text-sm">
+            <span className="font-medium text-yellow-800">API Quota</span>
+            <span className="text-yellow-700">
+              {current.remaining}/{current.limit}
+            </span>
+          </div>
+          {/* Custom progress bar */}
+          <div
+            className={clsx(
+              'h-2 w-full overflow-hidden rounded-full',
+              isVeryLow ? 'bg-red-200' : 'bg-yellow-200'
+            )}
+            data-testid="rate-limit-progress-container"
+          >
+            <div
+              className={clsx(
+                'h-full rounded-full transition-all duration-300',
+                isVeryLow ? 'bg-red-500' : 'bg-yellow-500'
+              )}
+              style={{ width: `${remainingPercentage}%` }}
+              data-testid="rate-limit-progress"
+              role="progressbar"
+              aria-valuenow={remainingPercentage}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${remainingPercentage}% of API quota remaining`}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -119,3 +119,6 @@ export type { FaviconBadgeProps } from './FaviconBadge';
 
 export { default as AmbientStatusProvider } from './AmbientStatusProvider';
 export type { AmbientStatusProviderProps } from './AmbientStatusProvider';
+
+export { default as RateLimitIndicator } from './RateLimitIndicator';
+export type { RateLimitIndicatorProps } from './RateLimitIndicator';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -259,3 +259,9 @@ export type {
 // ============================================================================
 
 export type { PerformanceAlert, AiModelMetrics } from './performance';
+
+// ============================================================================
+// Rate Limit Types
+// ============================================================================
+
+export type { RateLimitInfo, ApiResponse } from './rate-limit';

--- a/frontend/src/types/rate-limit.ts
+++ b/frontend/src/types/rate-limit.ts
@@ -1,0 +1,39 @@
+/**
+ * Rate Limit Types
+ *
+ * Types for rate limit information extracted from API response headers.
+ * The RateLimitInfo type is re-exported from the rate-limit-store for convenience.
+ *
+ * @see frontend/src/stores/rate-limit-store.ts - The Zustand store for rate limit state
+ */
+
+// Import RateLimitInfo for use in this file
+import type { RateLimitInfo } from '../stores/rate-limit-store';
+
+// Re-export RateLimitInfo for consumers of this module
+export type { RateLimitInfo };
+
+/**
+ * API response wrapper that includes optional rate limit information.
+ * Used when the caller needs access to both the response data and rate limit headers.
+ *
+ * @template T - The type of the response data
+ *
+ * @example
+ * ```typescript
+ * const response: ApiResponse<Event[]> = {
+ *   data: events,
+ *   rateLimit: {
+ *     limit: 100,
+ *     remaining: 95,
+ *     reset: 1704067200,
+ *   },
+ * };
+ * ```
+ */
+export interface ApiResponse<T> {
+  /** The response data from the API */
+  data: T;
+  /** Rate limit information extracted from response headers, if present */
+  rateLimit?: RateLimitInfo;
+}


### PR DESCRIPTION
## Summary
- Add `extractRateLimitInfo()` to parse X-RateLimit-* headers from API responses
- Create `RateLimitIndicator` component with quota warnings and countdown
- Create `RetryingIndicator` component showing retry state with spinner
- Integrate rate limit handling in QueryClient retry configuration

## Linear Issues
- [NEM-1967](https://linear.app/nemotron-v3-home-security/issue/NEM-1967) - Extract rate limit headers in API client
- [NEM-1969](https://linear.app/nemotron-v3-home-security/issue/NEM-1969) - Add rate limit indicator UI component
- [NEM-1970](https://linear.app/nemotron-v3-home-security/issue/NEM-1970) - Implement automatic retry with backoff on 429

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] 107 rate limit related tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)