### PR TITLE
feat: complete TanStack Query migration for 8 components (NEM-1885)

### DIFF
--- a/frontend/src/components/system/SystemSummaryRow.test.tsx
+++ b/frontend/src/components/system/SystemSummaryRow.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
 import SystemSummaryRow from './SystemSummaryRow';
 import { useHealthStatusQuery } from '../../hooks/useHealthStatusQuery';
-import { useModelZooStatus } from '../../hooks/useModelZooStatus';
+import { useModelZooStatusQuery } from '../../hooks/useModelZooStatusQuery';
 import { usePerformanceMetrics } from '../../hooks/usePerformanceMetrics';
 
 import type { PerformanceUpdate } from '../../hooks/usePerformanceMetrics';
@@ -11,7 +11,7 @@ import type { PerformanceUpdate } from '../../hooks/usePerformanceMetrics';
 // Mock the hooks
 vi.mock('../../hooks/usePerformanceMetrics');
 vi.mock('../../hooks/useHealthStatusQuery');
-vi.mock('../../hooks/useModelZooStatus');
+vi.mock('../../hooks/useModelZooStatusQuery');
 
 // Mock scrollIntoView
 const mockScrollIntoView = vi.fn();
@@ -95,10 +95,10 @@ const defaultModels: MockModel[] = [
 ];
 
 const defaultVramStats = {
-  budget_mb: 24576,
-  used_mb: 9200,
-  available_mb: 15376,
-  usage_percent: 37.4,
+  budgetMb: 24576,
+  usedMb: 9200,
+  availableMb: 15376,
+  usagePercent: 37.4,
 };
 
 const defaultServices = {
@@ -117,7 +117,7 @@ function setupMocks(overrides?: {
 }) {
   const mockedUsePerformanceMetrics = usePerformanceMetrics as Mock;
   const mockedUseHealthStatusQuery = useHealthStatusQuery as Mock;
-  const mockedUseModelZooStatus = useModelZooStatus as Mock;
+  const mockedUseModelZooStatusQuery = useModelZooStatusQuery as Mock;
 
   mockedUsePerformanceMetrics.mockReturnValue({
     current: overrides?.performance === null ? null : { ...defaultPerformanceData, ...overrides?.performance },
@@ -139,12 +139,13 @@ function setupMocks(overrides?: {
     refetch: vi.fn().mockResolvedValue({}),
   });
 
-  mockedUseModelZooStatus.mockReturnValue({
+  mockedUseModelZooStatusQuery.mockReturnValue({
     models: overrides?.models ?? defaultModels,
     vramStats: overrides?.vramStats ?? defaultVramStats,
     isLoading: false,
+    isRefetching: false,
     error: null,
-    refresh: vi.fn(),
+    refetch: vi.fn().mockResolvedValue({}),
   });
 }
 

--- a/frontend/src/components/system/SystemSummaryRow.tsx
+++ b/frontend/src/components/system/SystemSummaryRow.tsx
@@ -12,7 +12,7 @@ import {
 import { useCallback, useMemo } from 'react';
 
 import { useHealthStatusQuery } from '../../hooks/useHealthStatusQuery';
-import { useModelZooStatus } from '../../hooks/useModelZooStatus';
+import { useModelZooStatusQuery } from '../../hooks/useModelZooStatusQuery';
 import { usePerformanceMetrics } from '../../hooks/usePerformanceMetrics';
 
 // ============================================================================
@@ -292,7 +292,7 @@ export default function SystemSummaryRow({
   // Hooks for real-time data
   const { current, isConnected } = usePerformanceMetrics();
   const { services, overallStatus } = useHealthStatusQuery({ refetchInterval: 10000 });
-  const { models, vramStats } = useModelZooStatus({ pollingInterval: 10000 });
+  const { models, vramStats } = useModelZooStatusQuery({ refetchInterval: 10000 });
 
   // Scroll to section handler
   const handleIndicatorClick = useCallback(
@@ -445,8 +445,8 @@ export default function SystemSummaryRow({
       tooltipContent: [
         `Loaded models: ${loadedCount}`,
         `Total models: ${totalModels}`,
-        vramStats ? `VRAM used: ${formatGB(vramStats.used_mb / 1024)}` : 'VRAM: N/A',
-        vramStats ? `VRAM available: ${formatGB(vramStats.available_mb / 1024)}` : '',
+        vramStats ? `VRAM used: ${formatGB(vramStats.usedMb / 1024)}` : 'VRAM: N/A',
+        vramStats ? `VRAM available: ${formatGB(vramStats.availableMb / 1024)}` : '',
         ...loadedModels.slice(0, 3).map((m) => `- ${m.display_name || m.name}`),
         loadedModels.length > 3 ? `...and ${loadedModels.length - 3} more` : '',
       ].filter(Boolean),


### PR DESCRIPTION
## Summary
- Migrates 8 frontend components to TanStack Query for improved data fetching and caching
- Recovered from frozen swa8 session by merging into swa10

## Test plan
- [x] Backend unit tests pass (validated locally)
- [ ] CI pipeline validates all tests
- [ ] Frontend component behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)