### PR TITLE
feat: integrate WorkerSupervisor with main application lifecycle (NEM-2460)

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1357,6 +1357,27 @@ class Settings(BaseSettings):
         "Health monitoring and status broadcasts still occur when disabled.",
     )
 
+    # Worker Supervisor settings (NEM-2460)
+    # Controls the asyncio worker supervisor that monitors and auto-restarts crashed workers
+    worker_supervisor_check_interval: float = Field(
+        default=5.0,
+        ge=1.0,
+        le=60.0,
+        description="Interval in seconds between worker health checks by the supervisor.",
+    )
+    worker_supervisor_max_restarts: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description="Maximum number of restart attempts for a crashed worker before giving up.",
+    )
+    worker_supervisor_restart_window: float = Field(
+        default=300.0,
+        ge=60.0,
+        le=3600.0,
+        description="Time window in seconds for counting restart attempts.",
+    )
+
     # Container orchestrator settings (for Docker/Podman container management)
     # Environment variables use ORCHESTRATOR_ prefix (e.g., ORCHESTRATOR_ENABLED)
     orchestrator: OrchestratorSettings = Field(

--- a/backend/services/worker_supervisor.py
+++ b/backend/services/worker_supervisor.py
@@ -11,6 +11,7 @@ Features:
     - Broadcast status changes via WebSocket (service_status events)
     - Configurable max restart limit to prevent restart storms
     - Thread-safe restart handling with asyncio locks
+    - Callback support for on_restart and on_failure events (NEM-2460)
 
 Usage:
     from backend.services.worker_supervisor import (
@@ -58,6 +59,10 @@ if TYPE_CHECKING:
     from backend.services.event_broadcaster import EventBroadcaster
 
 logger = get_logger(__name__)
+
+# Type aliases for callbacks (NEM-2460)
+OnRestartCallback = Callable[[str, int, str | None], Awaitable[None]]
+OnFailureCallback = Callable[[str, str | None], Awaitable[None]]
 
 
 class WorkerStatus(Enum):
@@ -123,21 +128,33 @@ class WorkerSupervisor:
 
     This supervisor monitors registered worker tasks and automatically
     restarts them with exponential backoff when they fail.
+
+    Callbacks (NEM-2460):
+        on_restart: Called when a worker is about to be restarted with (name, attempt, error).
+        on_failure: Called when a worker exceeds max restarts with (name, error).
     """
 
     def __init__(
         self,
         config: SupervisorConfig | None = None,
         broadcaster: EventBroadcaster | None = None,
+        on_restart: OnRestartCallback | None = None,
+        on_failure: OnFailureCallback | None = None,
     ) -> None:
         """Initialize the WorkerSupervisor.
 
         Args:
             config: Supervisor configuration. Uses defaults if not provided.
             broadcaster: Optional EventBroadcaster for status updates.
+            on_restart: Optional async callback called when a worker is restarted.
+                Signature: async def on_restart(name: str, attempt: int, error: str | None)
+            on_failure: Optional async callback called when a worker exceeds max restarts.
+                Signature: async def on_failure(name: str, error: str | None)
         """
         self._config = config or SupervisorConfig()
         self._broadcaster = broadcaster
+        self._on_restart = on_restart
+        self._on_failure = on_failure
         self._workers: dict[str, WorkerInfo] = {}
         self._running = False
         self._monitor_task: asyncio.Task[None] | None = None
@@ -373,6 +390,13 @@ class WorkerSupervisor:
                         WorkerStatus.FAILED,
                         f"Exceeded max restarts ({worker.max_restarts})",
                     )
+
+                    # Invoke on_failure callback (NEM-2460)
+                    if self._on_failure is not None:
+                        try:
+                            await self._on_failure(name, worker.error)
+                        except Exception as cb_err:
+                            logger.warning(f"on_failure callback raised exception: {cb_err}")
                 return
 
             # Calculate backoff
@@ -387,6 +411,13 @@ class WorkerSupervisor:
                 f"(attempt {worker.restart_count + 1}/{worker.max_restarts})"
             )
             await self._broadcast_status(name, WorkerStatus.RESTARTING)
+
+            # Invoke on_restart callback (NEM-2460)
+            if self._on_restart is not None:
+                try:
+                    await self._on_restart(name, worker.restart_count + 1, worker.error)
+                except Exception as cb_err:
+                    logger.warning(f"on_restart callback raised exception: {cb_err}")
 
             # Wait for backoff
             await asyncio.sleep(backoff)
@@ -515,19 +546,28 @@ _supervisor: WorkerSupervisor | None = None
 def get_worker_supervisor(
     config: SupervisorConfig | None = None,
     broadcaster: EventBroadcaster | None = None,
+    on_restart: OnRestartCallback | None = None,
+    on_failure: OnFailureCallback | None = None,
 ) -> WorkerSupervisor:
     """Get the singleton WorkerSupervisor instance.
 
     Args:
         config: Configuration (only used on first call).
         broadcaster: EventBroadcaster (only used on first call).
+        on_restart: Optional callback for worker restarts (only used on first call).
+        on_failure: Optional callback for worker failures (only used on first call).
 
     Returns:
         The WorkerSupervisor singleton.
     """
     global _supervisor  # noqa: PLW0603
     if _supervisor is None:
-        _supervisor = WorkerSupervisor(config=config, broadcaster=broadcaster)
+        _supervisor = WorkerSupervisor(
+            config=config,
+            broadcaster=broadcaster,
+            on_restart=on_restart,
+            on_failure=on_failure,
+        )
     return _supervisor
 
 


### PR DESCRIPTION
## Summary

- Add callback support (`on_restart`, `on_failure`) to `WorkerSupervisor` for crash recovery notifications
- Add configuration settings for worker supervisor check interval and max restarts
- Create factory functions in `pipeline_workers.py` for supervisor integration
- Initialize `WorkerSupervisor` in FastAPI lifespan with logging callbacks
- Register detection, analysis, batch_timeout, and metrics workers with supervisor

## Test Plan

- [x] All 26 existing `test_worker_supervisor.py` tests pass
- [x] All 163 `test_config.py` tests pass  
- [x] mypy type checking passes
- [x] ruff linting passes
- [x] Pre-commit hooks pass

## Linear Issue

Closes NEM-2460

---
Generated with [Claude Code](https://claude.com/claude-code)