### PR TITLE
fix: resolve dead code detection CI failure (NEM-2643)

### DIFF
--- a/backend/tests/integration/test_websocket.py
+++ b/backend/tests/integration/test_websocket.py
@@ -50,9 +50,9 @@ def _get_common_lifespan_mocks():
 
     # Mock pubsub for event broadcaster - must be an async iterator
     async def mock_listen(*args, **kwargs):
-        # Yield nothing - empty async generator
-        return
-        yield  # Make this an async generator
+        # Empty async generator using yield from empty iterable pattern
+        for _ in []:
+            yield
 
     mock_pubsub = MagicMock()
     mock_redis_client._pubsub = mock_pubsub

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,6 @@
         "@tanstack/react-query": "^5.90.16",
         "@tanstack/react-query-devtools": "^5.91.2",
         "@tremor/react": "^3.17.4",
-        "@types/dompurify": "^3.2.0",
         "clsx": "^2.1.0",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
@@ -3968,16 +3967,6 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,6 @@
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-query-devtools": "^5.91.2",
     "@tremor/react": "^3.17.4",
-    "@types/dompurify": "^3.2.0",
     "clsx": "^2.1.0",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
## Summary
- Fix dead code detection (vulture/knip) failing on main branch
- Replace unreachable `return; yield` pattern with `for _ in []: yield` in test_websocket.py
- Remove unused `@types/dompurify` package (dompurify provides own types since v3)

## Test plan
- [x] Vulture passes locally: `uv run vulture backend/ vulture_whitelist.py --config pyproject.toml`
- [x] Knip passes locally: `cd frontend && npx knip`
- [x] Pre-commit hooks pass
- [x] Worker supervisor unit tests pass
- [x] WebSocket integration tests pass (serial mode)

## Related
- Fixes: https://linear.app/nemotron-v3-home-security/issue/NEM-2643
- CI Run: https://github.com/mikesvoboda/nemotron-v3-home-security-intelligence/actions/runs/21005164688

Generated with [Claude Code](https://claude.com/claude-code)