### PR TITLE
feat(frontend): auto-generate SSL certificates inside container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -366,14 +366,14 @@ services:
       # HTTPS port mapping (only used when SSL_ENABLED=true)
       # Default 8443 to avoid privileged port issues with rootless containers
       - '${FRONTEND_HTTPS_PORT:-8443}:8443'
-    volumes:
-      # SSL certificates volume mount (optional - only needed when SSL_ENABLED=true)
-      # Create certificates:
-      #   For development (self-signed): ./scripts/generate-ssl-cert.sh
-      #   For production: use Let's Encrypt, Cloudflare, or your CA
-      # Mount directory containing cert.pem and key.pem (or custom paths via SSL_CERT_PATH/SSL_KEY_PATH)
-      - ${SSL_CERT_DIR:-./certs}:/etc/nginx/certs:ro
+    # Optional: Mount pre-existing certificates from host
+    # If not mounted, container auto-generates self-signed certs when SSL_ENABLED=true
+    # volumes:
+    #   - ${SSL_CERT_DIR:-./certs}:/etc/nginx/certs:ro
     environment:
+      # Extra SANs for the auto-generated certificate (e.g., your server's IP)
+      # Format: IP:192.168.1.100,DNS:myhost.local
+      - SSL_SAN_EXTRA=${SSL_SAN_EXTRA:-}
       # SSL/TLS Configuration
       # Set SSL_ENABLED=true to enable HTTPS (requires valid certificates)
       - SSL_ENABLED=${SSL_ENABLED:-false}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -89,9 +89,12 @@ LABEL org.opencontainers.image.source="https://github.com/mikesvoboda/nemotron-v
 # Switch to root temporarily to install wget and configure files
 USER root
 
-# Install wget for healthcheck
+# Install wget for healthcheck and openssl for self-signed cert generation
+# Create certs directory for auto-generated SSL certificates
 # hadolint ignore=DL3018
-RUN apk add --no-cache wget
+RUN apk add --no-cache wget openssl && \
+    mkdir -p /etc/nginx/certs && \
+    chown nginx:nginx /etc/nginx/certs
 
 # Copy built assets from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html
@@ -101,10 +104,10 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy entrypoint script (injects DNS resolver at runtime for Docker/Podman portability)
 COPY docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
 
-# Ensure nginx user owns the necessary directories
-RUN chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/log/nginx /etc/nginx/conf.d
+# Make entrypoint executable and ensure nginx user owns necessary directories
+RUN chmod +x /docker-entrypoint.sh && \
+    chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/log/nginx /etc/nginx/conf.d
 
 # Switch back to non-root nginx user
 USER nginx

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -53,7 +53,9 @@ server {
 
     # Content Security Policy - restrict resource loading
     # Note: 'unsafe-inline' for styles is required by Tailwind/Tremor
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;
+    # Note: upgrade-insecure-requests is NOT included here (HTTP mode) - it's only in HTTPS mode
+    # to avoid breaking HTTP-only deployments where HTTPS is not available
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
 
     # Permissions Policy - restrict browser features
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;


### PR DESCRIPTION
## Summary
- Modified frontend Dockerfile to include openssl and create /etc/nginx/certs directory
- Added auto-generation of self-signed SSL certificates in docker-entrypoint.sh when SSL_ENABLED=true
- Removed `upgrade-insecure-requests` from HTTP mode CSP (was causing blank page on remote access)
- Added SSL_SAN_EXTRA environment variable support for additional IP/DNS entries in certificates
- Commented out host volume mount in docker-compose.prod.yml to enable in-container cert generation

## Problem Solved
When accessing the frontend remotely (e.g., http://192.168.1.145:5173), the page would render blank because:
1. CSP header included `upgrade-insecure-requests` directive
2. Browser upgraded HTTP requests to HTTPS
3. No HTTPS server was running, causing asset loading failures

## Changes
- `frontend/Dockerfile`: Add openssl, create certs directory with nginx ownership
- `frontend/docker-entrypoint.sh`: Auto-generate self-signed certs when SSL_ENABLED=true
- `frontend/nginx.conf`: Remove upgrade-insecure-requests from HTTP mode CSP
- `docker-compose.prod.yml`: Comment out certs volume mount, add SSL_SAN_EXTRA env var

## Test plan
- [x] Verified HTTPS works locally: `curl -sk https://192.168.1.145:8444/health` returns "healthy"
- [x] Unit tests pass on main branch
- [ ] CI will verify E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)