### PR TITLE
feat: migrate Dev Tools functionality to Operations page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,13 +73,6 @@ const SettingsPage = lazy(() => import('./components/settings/SettingsPage'));
 // Trash (soft-deleted events)
 const TrashPage = lazy(() => import('./pages/TrashPage'));
 
-// Developer Tools (debug mode only)
-const DeveloperToolsPage = lazy(() =>
-  import('./components/developer-tools').then((module) => ({
-    default: module.DeveloperToolsPage,
-  }))
-);
-
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -111,7 +104,6 @@ export default function App() {
                           <Route path="/system" element={<Navigate to="/operations" replace />} />
                           <Route path="/settings" element={<SettingsPage />} />
                           <Route path="/trash" element={<TrashPage />} />
-                          <Route path="/dev-tools" element={<DeveloperToolsPage />} />
                         </Routes>
                       </PageTransition>
                     </Suspense>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -13,7 +13,6 @@ import {
   Brain,
   ClipboardCheck,
   Trash2,
-  Terminal,
 } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 
@@ -43,7 +42,6 @@ const navItems: NavItem[] = [
   { id: 'trash', label: 'Trash', icon: Trash2, path: '/trash' },
   { id: 'system', label: 'System', icon: Server, path: '/system' },
   { id: 'logs', label: 'Logs', icon: ScrollText, path: '/logs' },
-  { id: 'dev-tools', label: 'Dev Tools', icon: Terminal, path: '/dev-tools' },
   {
     id: 'settings',
     label: 'Settings',

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -9,11 +9,8 @@ import {
   Settings as SettingsIcon,
   Shield,
   Sliders,
-  Terminal,
-  ExternalLink,
 } from 'lucide-react';
 import { Fragment } from 'react';
-import { Link } from 'react-router-dom';
 
 import { SecureContextWarning } from '../common';
 import AlertRulesSettings from './AlertRulesSettings';
@@ -23,7 +20,6 @@ import CamerasSettings from './CamerasSettings';
 import NotificationSettings from './NotificationSettings';
 import ProcessingSettings from './ProcessingSettings';
 import { PromptManagementPage } from './prompts';
-import { useSystemConfigQuery } from '../../hooks/useSystemConfigQuery';
 import FileOperationsPanel from '../system/FileOperationsPanel';
 
 /**
@@ -50,10 +46,8 @@ import FileOperationsPanel from '../system/FileOperationsPanel';
  *
  * @see NEM-2356 - Add CalibrationPanel to Settings page
  * @see NEM-2388 - Add FileOperationsPanel to Settings page
- * @see NEM-2719 - Developer Tools link when debug mode is enabled
  */
 export default function SettingsPage() {
-  const { debugEnabled } = useSystemConfigQuery();
 
   const tabs = [
     {
@@ -116,18 +110,6 @@ export default function SettingsPage() {
             <p className="text-body-sm mt-2">Configure your security monitoring system</p>
           </div>
 
-          {/* Developer Tools Link - only visible when debug mode is enabled */}
-          {debugEnabled && (
-            <Link
-              to="/dev-tools"
-              className="flex items-center gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-2 text-sm font-medium text-yellow-500 transition-colors hover:bg-yellow-500/20"
-              data-testid="dev-tools-link"
-            >
-              <Terminal className="h-4 w-4" />
-              Developer Tools
-              <ExternalLink className="h-3 w-3" />
-            </Link>
-          )}
         </div>
 
         {/* Secure Context Warning - shown when not using HTTPS */}

--- a/frontend/src/components/system/SystemMonitoringPage.tsx
+++ b/frontend/src/components/system/SystemMonitoringPage.tsx
@@ -6,14 +6,15 @@ import {
   BarChart2,
   ExternalLink,
   HardDrive,
+  Activity,
+  Video,
+  FileText,
+  Terminal,
+  Database,
+  Wrench,
 } from 'lucide-react';
 import { useEffect, useState, useRef } from 'react';
 
-import CircuitBreakerPanel from './CircuitBreakerPanel';
-import CollapsibleSection from './CollapsibleSection';
-import DebugModeToggle from './DebugModeToggle';
-import FileOperationsPanel from './FileOperationsPanel';
-import PipelineFlowVisualization from './PipelineFlowVisualization';
 import { useSystemPageSections } from '../../hooks/useSystemPageSections';
 import {
   fetchTelemetry,
@@ -25,6 +26,18 @@ import {
   type CircuitBreakersResponse,
   type WorkerStatus,
 } from '../../services/api';
+import {
+  ProfilingPanel,
+  RecordingReplayPanel,
+  ConfigInspectorPanel,
+  LogLevelPanel,
+  TestDataPanel,
+} from '../developer-tools';
+import CircuitBreakerPanel from './CircuitBreakerPanel';
+import CollapsibleSection from './CollapsibleSection';
+import DebugModeToggle from './DebugModeToggle';
+import FileOperationsPanel from './FileOperationsPanel';
+import PipelineFlowVisualization from './PipelineFlowVisualization';
 
 import type {
   PipelineStageData,
@@ -420,6 +433,81 @@ export default function SystemMonitoringPage() {
                 data-testid="file-operations-panel-section"
               />
             </CollapsibleSection>
+          </div>
+        </div>
+
+        {/* Developer Tools Section */}
+        <div className="mt-8">
+          <div className="mb-4 flex items-center gap-2">
+            <Wrench className="h-5 w-5 text-[#76B900]" />
+            <h2 className="text-xl font-semibold text-white">Developer Tools</h2>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            {/* Profiling Panel */}
+            <div id="section-profiling">
+              <CollapsibleSection
+                title="Performance Profiling"
+                icon={<Activity className="h-5 w-5 text-[#76B900]" />}
+                isOpen={sectionStates['profiling']}
+                onToggle={() => toggleSection('profiling')}
+                data-testid="profiling-section"
+              >
+                <ProfilingPanel data-testid="profiling-panel-section" />
+              </CollapsibleSection>
+            </div>
+
+            {/* Recording & Replay Panel */}
+            <div id="section-recording-replay">
+              <CollapsibleSection
+                title="Recording & Replay"
+                icon={<Video className="h-5 w-5 text-[#76B900]" />}
+                isOpen={sectionStates['recording-replay']}
+                onToggle={() => toggleSection('recording-replay')}
+                data-testid="recording-replay-section"
+              >
+                <RecordingReplayPanel data-testid="recording-replay-panel-section" />
+              </CollapsibleSection>
+            </div>
+
+            {/* Config Inspector Panel */}
+            <div id="section-config-inspector">
+              <CollapsibleSection
+                title="Configuration Inspector"
+                icon={<FileText className="h-5 w-5 text-[#76B900]" />}
+                isOpen={sectionStates['config-inspector']}
+                onToggle={() => toggleSection('config-inspector')}
+                data-testid="config-inspector-section"
+              >
+                <ConfigInspectorPanel data-testid="config-inspector-panel-section" />
+              </CollapsibleSection>
+            </div>
+
+            {/* Log Level Panel */}
+            <div id="section-log-level">
+              <CollapsibleSection
+                title="Log Level Control"
+                icon={<Terminal className="h-5 w-5 text-[#76B900]" />}
+                isOpen={sectionStates['log-level']}
+                onToggle={() => toggleSection('log-level')}
+                data-testid="log-level-section"
+              >
+                <LogLevelPanel data-testid="log-level-panel-section" />
+              </CollapsibleSection>
+            </div>
+
+            {/* Test Data Panel */}
+            <div id="section-test-data">
+              <CollapsibleSection
+                title="Test Data Management"
+                icon={<Database className="h-5 w-5 text-[#76B900]" />}
+                isOpen={sectionStates['test-data']}
+                onToggle={() => toggleSection('test-data')}
+                data-testid="test-data-section"
+              >
+                <TestDataPanel data-testid="test-data-panel-section" />
+              </CollapsibleSection>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/hooks/useSystemPageSections.ts
+++ b/frontend/src/hooks/useSystemPageSections.ts
@@ -16,7 +16,12 @@ export type SystemSectionId =
   | 'host-system'
   | 'circuit-breakers'
   | 'file-operations'
-  | 'services';
+  | 'services'
+  | 'profiling'
+  | 'recording-replay'
+  | 'config-inspector'
+  | 'log-level'
+  | 'test-data';
 
 /**
  * Default expanded state for each section
@@ -43,6 +48,11 @@ const DEFAULT_SECTION_STATES: Record<SystemSectionId, boolean> = {
   'circuit-breakers': false,
   'file-operations': false,
   services: false,
+  profiling: false,
+  'recording-replay': false,
+  'config-inspector': false,
+  'log-level': false,
+  'test-data': false,
 };
 
 const STORAGE_KEY = 'system-page-sections';


### PR DESCRIPTION
## Summary
- Move all 5 Dev Tools panels to Operations page as collapsible sections under a "Developer Tools" header
- Remove Dev Tools from sidebar navigation
- Remove /dev-tools route from App.tsx
- Clean up Dev Tools link from Settings page

## Developer Tools Migrated
- **Performance Profiling** - CPU profiling with activity analysis
- **Recording & Replay** - Request recording/replay debugging
- **Configuration Inspector** - Application configuration viewer
- **Log Level Control** - Runtime log level adjustment
- **Test Data Management** - Test data seeding and cleanup

## Test Plan
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Backend unit tests pass
- [ ] CI pipeline runs all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)