### PR TITLE
feat: Add pull-to-refresh for mobile event lists (NEM-2970)

### DIFF
--- a/frontend/src/components/common/PullToRefresh.test.tsx
+++ b/frontend/src/components/common/PullToRefresh.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * @fileoverview Tests for PullToRefresh component.
+ *
+ * This component provides visual feedback for pull-to-refresh gestures
+ * and wraps content with touch event handling for mobile devices.
+ *
+ * @see NEM-2970
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { PullToRefresh } from './PullToRefresh';
+
+describe('PullToRefresh', () => {
+  // Helper to create touch events
+  function createTouchEvent(
+    type: 'touchstart' | 'touchmove' | 'touchend',
+    clientY: number,
+    clientX: number = 0
+  ): TouchEvent {
+    const touch = {
+      clientY,
+      clientX,
+      identifier: 0,
+      target: document.createElement('div'),
+      screenX: clientX,
+      screenY: clientY,
+      pageX: clientX,
+      pageY: clientY,
+      radiusX: 0,
+      radiusY: 0,
+      rotationAngle: 0,
+      force: 0,
+    } as Touch;
+
+    const event = new TouchEvent(type, {
+      touches: type === 'touchend' ? [] : [touch],
+      changedTouches: [touch],
+      bubbles: true,
+      cancelable: true,
+    });
+
+    return event;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders children content', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <PullToRefresh onRefresh={onRefresh}>
+          <div data-testid="child-content">Test Content</div>
+        </PullToRefresh>
+      );
+
+      expect(screen.getByTestId('child-content')).toBeInTheDocument();
+      expect(screen.getByText('Test Content')).toBeInTheDocument();
+    });
+
+    it('renders pull-to-refresh container', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <PullToRefresh onRefresh={onRefresh}>
+          <div>Content</div>
+        </PullToRefresh>
+      );
+
+      expect(screen.getByTestId('pull-to-refresh-container')).toBeInTheDocument();
+    });
+
+    it('applies custom className', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <PullToRefresh onRefresh={onRefresh} className="custom-class">
+          <div>Content</div>
+        </PullToRefresh>
+      );
+
+      expect(screen.getByTestId('pull-to-refresh-container')).toHaveClass('custom-class');
+    });
+  });
+
+  describe('pull indicator', () => {
+    it('hides pull indicator initially', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <PullToRefresh onRefresh={onRefresh}>
+          <div>Content</div>
+        </PullToRefresh>
+      );
+
+      const indicator = screen.queryByTestId('pull-indicator');
+      // Indicator should not be visible or have height 0
+      expect(indicator?.style.height).toBe('0px');
+    });
+
+    it('shows pull indicator during pull gesture', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <PullToRefresh onRefresh={onRefresh}>
+          <div>Content</div>
+        </PullToRefresh>
+      );
+
+      const container = screen.getByTestId('pull-to-refresh-container');
+
+      act(() => {
+        container.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        container.dispatchEvent(createTouchEvent('touchmove', 100));
+      });
+
+      const indicator = screen.getByTestId('pull-indicator');
+      // Indicator should have positive height when pulling
+      const heightValue = parseInt(indicator.style.height || '0', 10);
+      expect(heightValue).toBeGreaterThan(0);
+    });
+  });
+
+  describe('refresh spinner', () => {
+    it('shows spinner during refresh', async () => {
+      let resolveRefresh: () => void;
+      const onRefresh = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+
+      render(
+        <PullToRefresh onRefresh={onRefresh}>
+          <div>Content</div>
+        </PullToRefresh>
+      );
+
+      const container = screen.getByTestId('pull-to-refresh-container');
+
+      // Trigger refresh
+      act(() => {
+        container.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        container.dispatchEvent(createTouchEvent('touchmove', 180)); // Past threshold with resistance
+      });
+
+      act(() => {
+        container.dispatchEvent(createTouchEvent('touchend', 180));
+      });
+
+      // Should show spinner while refreshing
+      await waitFor(() => {
+        expect(screen.getByTestId('refresh-spinner')).toBeInTheDocument();
+      });
+
+      // Resolve refresh
+      await act(async () => {
+        resolveRefresh();
+        await Promise.resolve(); // Flush microtasks for async state updates
+      });
+    });
+
+    it('hides spinner after refresh completes', async () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <PullToRefresh onRefresh={onRefresh}>
+          <div>Content</div>
+        </PullToRefresh>
+      );
+
+      const container = screen.getByTestId('pull-to-refresh-container');
+
+      // Trigger refresh
+      act(() => {
+        container.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        container.dispatchEvent(createTouchEvent('touchmove', 180));
+      });
+
+      await act(async () => {
+        container.dispatchEvent(createTouchEvent('touchend', 180));
+        await Promise.resolve(); // Flush microtasks for async state updates
+      });
+
+      // Wait for refresh to complete and spinner to hide
+      await waitFor(() => {
+        expect(screen.queryByTestId('refresh-spinner')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('external isRefreshing', () => {
+    it('shows spinner when isRefreshing prop is true', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <PullToRefresh onRefresh={onRefresh} isRefreshing={true}>
+          <div>Content</div>
+        </PullToRefresh>
+      );
+
+      expect(screen.getByTestId('refresh-spinner')).toBeInTheDocument();
+    });
+
+    it('hides spinner when isRefreshing prop is false', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <PullToRefresh onRefresh={onRefresh} isRefreshing={false}>
+          <div>Content</div>
+        </PullToRefresh>
+      );
+
+      expect(screen.queryByTestId('refresh-spinner')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('disabled state', () => {
+    it('does not show indicator when disabled', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <PullToRefresh onRefresh={onRefresh} disabled={true}>
+          <div>Content</div>
+        </PullToRefresh>
+      );
+
+      const container = screen.getByTestId('pull-to-refresh-container');
+
+      act(() => {
+        container.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        container.dispatchEvent(createTouchEvent('touchmove', 100));
+      });
+
+      const indicator = screen.getByTestId('pull-indicator');
+      const heightValue = parseInt(indicator.style.height || '0', 10);
+      expect(heightValue).toBe(0);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has appropriate aria attributes', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <PullToRefresh onRefresh={onRefresh}>
+          <div>Content</div>
+        </PullToRefresh>
+      );
+
+      const container = screen.getByTestId('pull-to-refresh-container');
+      expect(container).toHaveAttribute('role', 'region');
+      expect(container).toHaveAttribute('aria-label', 'Pull to refresh content');
+    });
+
+    it('has live region for refresh status', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <PullToRefresh onRefresh={onRefresh} isRefreshing={true}>
+          <div>Content</div>
+        </PullToRefresh>
+      );
+
+      // Look for the sr-only live region
+      const liveRegion = screen.getByRole('status');
+      expect(liveRegion).toBeInTheDocument();
+      expect(liveRegion).toHaveTextContent(/refreshing/i);
+    });
+  });
+});

--- a/frontend/src/components/common/PullToRefresh.tsx
+++ b/frontend/src/components/common/PullToRefresh.tsx
@@ -1,0 +1,143 @@
+/**
+ * PullToRefresh Component
+ *
+ * Provides pull-to-refresh functionality for mobile devices with visual feedback.
+ * Wraps content and detects pull-down gestures at the top of the container.
+ *
+ * Features:
+ * - Pull indicator that rotates based on pull progress
+ * - Loading spinner during refresh
+ * - Configurable threshold and visual styles
+ * - Accessibility support with ARIA attributes
+ *
+ * @see NEM-2970
+ *
+ * @example
+ * ```tsx
+ * <PullToRefresh onRefresh={async () => await refetch()} isRefreshing={isFetching}>
+ *   <EventList events={events} />
+ * </PullToRefresh>
+ * ```
+ */
+
+import { RefreshCw } from 'lucide-react';
+
+import { usePullToRefresh } from '../../hooks/usePullToRefresh';
+
+import type { ReactNode } from 'react';
+
+
+export interface PullToRefreshProps {
+  /**
+   * Content to wrap with pull-to-refresh functionality.
+   */
+  children: ReactNode;
+
+  /**
+   * Callback function when refresh is triggered.
+   * Should return a Promise that resolves when refresh is complete.
+   */
+  onRefresh: () => Promise<void>;
+
+  /**
+   * External control of refreshing state.
+   * Useful when refresh state is managed externally (e.g., by React Query).
+   */
+  isRefreshing?: boolean;
+
+  /**
+   * Whether pull-to-refresh is disabled.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * Minimum pull distance in pixels to trigger refresh.
+   * @default 80
+   */
+  threshold?: number;
+
+  /**
+   * Additional CSS classes for the container.
+   */
+  className?: string;
+}
+
+/**
+ * PullToRefresh component that wraps content with pull-to-refresh functionality.
+ */
+export function PullToRefresh({
+  children,
+  onRefresh,
+  isRefreshing: externalIsRefreshing,
+  disabled = false,
+  threshold = 80,
+  className = '',
+}: PullToRefreshProps) {
+  const {
+    containerRef,
+    isPulling,
+    isRefreshing: internalIsRefreshing,
+    pullDistance,
+    pullProgress,
+  } = usePullToRefresh({
+    onRefresh,
+    threshold,
+    disabled,
+    isRefreshing: externalIsRefreshing,
+  });
+
+  // Use external isRefreshing if provided, otherwise use internal
+  const isRefreshing = externalIsRefreshing ?? internalIsRefreshing;
+
+  // Calculate rotation based on pull progress (0-180 degrees)
+  const rotation = pullProgress * 180;
+
+  // Calculate indicator height (capped at threshold)
+  const indicatorHeight = Math.min(pullDistance, threshold);
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="pull-to-refresh-container"
+      className={`touch-pan-y overflow-auto ${className}`}
+      role="region"
+      aria-label="Pull to refresh content"
+    >
+      {/* Pull indicator */}
+      <div
+        data-testid="pull-indicator"
+        className="flex items-center justify-center overflow-hidden transition-[height] duration-75"
+        style={{ height: `${isPulling ? indicatorHeight : 0}px` }}
+        aria-hidden="true"
+      >
+        <div
+          className="text-[#76B900] transition-transform"
+          style={{ transform: `rotate(${rotation}deg)` }}
+        >
+          <RefreshCw className="h-6 w-6" />
+        </div>
+      </div>
+
+      {/* Refresh spinner (fixed at top while refreshing) */}
+      {isRefreshing && (
+        <div
+          data-testid="refresh-spinner"
+          className="flex items-center justify-center py-4"
+        >
+          <RefreshCw className="h-6 w-6 animate-spin text-[#76B900]" />
+        </div>
+      )}
+
+      {/* Screen reader status for accessibility */}
+      <div role="status" className="sr-only" aria-live="polite">
+        {isRefreshing ? 'Refreshing content...' : ''}
+      </div>
+
+      {/* Main content */}
+      <div>{children}</div>
+    </div>
+  );
+}
+
+export default PullToRefresh;

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -122,6 +122,10 @@ export { default as SafeErrorMessage } from './SafeErrorMessage';
 export type { SafeErrorMessageProps } from './SafeErrorMessage';
 export { sanitizeErrorMessage, extractErrorMessage } from '../../utils/sanitize';
 
+// Pull-to-refresh component (NEM-2970)
+export { PullToRefresh, default as PullToRefreshDefault } from './PullToRefresh';
+export type { PullToRefreshProps } from './PullToRefresh';
+
 export { SkipLink, default as SkipLinkDefault } from './SkipLink';
 export type { SkipLinkProps } from './SkipLink';
 

--- a/frontend/src/hooks/__tests__/usePullToRefresh.test.ts
+++ b/frontend/src/hooks/__tests__/usePullToRefresh.test.ts
@@ -1,0 +1,569 @@
+/**
+ * @fileoverview Tests for usePullToRefresh hook.
+ *
+ * This hook detects pull-down gestures at the top of a scrollable container
+ * to trigger a refresh action on mobile devices.
+ *
+ * @see NEM-2970
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { usePullToRefresh } from '../usePullToRefresh';
+
+describe('usePullToRefresh', () => {
+  // Helper to create touch events
+  function createTouchEvent(
+    type: 'touchstart' | 'touchmove' | 'touchend',
+    clientY: number,
+    clientX: number = 0
+  ): TouchEvent {
+    const touch = {
+      clientY,
+      clientX,
+      identifier: 0,
+      target: document.createElement('div'),
+      screenX: clientX,
+      screenY: clientY,
+      pageX: clientX,
+      pageY: clientY,
+      radiusX: 0,
+      radiusY: 0,
+      rotationAngle: 0,
+      force: 0,
+    } as Touch;
+
+    const event = new TouchEvent(type, {
+      touches: type === 'touchend' ? [] : [touch],
+      changedTouches: [touch],
+      bubbles: true,
+      cancelable: true,
+    });
+
+    return event;
+  }
+
+  // Mock element for ref
+  let mockElement: HTMLDivElement;
+
+  beforeEach(() => {
+    mockElement = document.createElement('div');
+    document.body.appendChild(mockElement);
+
+    // Mock scrollTop as 0 (at top of scroll container)
+    Object.defineProperty(mockElement, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    document.body.removeChild(mockElement);
+    vi.restoreAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('returns initial state with isPulling false', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+      expect(result.current.isPulling).toBe(false);
+      expect(result.current.isRefreshing).toBe(false);
+      expect(result.current.pullDistance).toBe(0);
+      expect(result.current.pullProgress).toBe(0);
+    });
+
+    it('returns a ref callback', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+      expect(typeof result.current.containerRef).toBe('function');
+    });
+  });
+
+  describe('pull gesture detection', () => {
+    it('sets isPulling true when touch starts and moves down', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+      // Attach ref to element
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      // Simulate touch start
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      // Simulate touch move down
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 50));
+      });
+
+      expect(result.current.isPulling).toBe(true);
+    });
+
+    it('updates pullDistance during pull', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 60));
+      });
+
+      // Pull distance should be positive (moved down)
+      expect(result.current.pullDistance).toBeGreaterThan(0);
+    });
+
+    it('calculates pullProgress as ratio of pullDistance to threshold', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const threshold = 80;
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 40));
+      });
+
+      // Progress should be approximately 0.5 (40/80)
+      // Note: resistance may affect actual value
+      expect(result.current.pullProgress).toBeGreaterThan(0);
+      expect(result.current.pullProgress).toBeLessThanOrEqual(1);
+    });
+
+    it('clamps pullProgress to max of 1', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const threshold = 80;
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      // Pull way past threshold
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 200));
+      });
+
+      expect(result.current.pullProgress).toBe(1);
+    });
+  });
+
+  describe('refresh trigger', () => {
+    it('triggers onRefresh when released past threshold', async () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const threshold = 80;
+      // With default resistance of 0.5, need to pull 160+ pixels to get 80+ pullDistance
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 180)); // 180 * 0.5 = 90 > 80
+      });
+
+      await act(async () => {
+        mockElement.dispatchEvent(createTouchEvent('touchend', 180));
+        await Promise.resolve(); // Flush microtasks for async state updates
+      });
+
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not trigger onRefresh when released before threshold', async () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const threshold = 80;
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 30));
+      });
+
+      await act(async () => {
+        mockElement.dispatchEvent(createTouchEvent('touchend', 30));
+        await Promise.resolve(); // Flush microtasks for async state updates
+      });
+
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+
+    it('sets isRefreshing true while refresh is in progress', async () => {
+      let resolveRefresh: () => void;
+      const onRefresh = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+
+      const threshold = 80;
+      // With default resistance of 0.5, need to pull 160+ pixels to get 80+ pullDistance
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 180)); // 180 * 0.5 = 90 > 80
+      });
+
+      // Start refresh but don't resolve yet
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchend', 180));
+      });
+
+      // Should be refreshing
+      expect(result.current.isRefreshing).toBe(true);
+
+      // Resolve the refresh
+      await act(async () => {
+        resolveRefresh();
+        await Promise.resolve(); // Flush microtasks for async state updates
+      });
+
+      // Should no longer be refreshing
+      expect(result.current.isRefreshing).toBe(false);
+    });
+
+    it('resets state after refresh completes', async () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const threshold = 80;
+      // With default resistance of 0.5, need to pull 160+ pixels to get 80+ pullDistance
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 180)); // 180 * 0.5 = 90 > 80
+      });
+
+      await act(async () => {
+        mockElement.dispatchEvent(createTouchEvent('touchend', 180));
+        await Promise.resolve(); // Flush microtasks for async state updates
+      });
+
+      expect(result.current.isPulling).toBe(false);
+      expect(result.current.pullDistance).toBe(0);
+      expect(result.current.pullProgress).toBe(0);
+    });
+  });
+
+  describe('scroll position check', () => {
+    it('does not trigger pull when not at top of scroll container', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+      // Set scrollTop to non-zero value
+      Object.defineProperty(mockElement, 'scrollTop', {
+        value: 100,
+        writable: true,
+        configurable: true,
+      });
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 50));
+      });
+
+      expect(result.current.isPulling).toBe(false);
+      expect(result.current.pullDistance).toBe(0);
+    });
+  });
+
+  describe('upward swipe handling', () => {
+    it('ignores upward swipes (negative delta)', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 100));
+      });
+
+      // Move up (negative delta)
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 50));
+      });
+
+      expect(result.current.isPulling).toBe(false);
+      expect(result.current.pullDistance).toBe(0);
+    });
+  });
+
+  describe('disabled state', () => {
+    it('does not respond to gestures when disabled', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh, disabled: true }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 100));
+      });
+
+      expect(result.current.isPulling).toBe(false);
+    });
+
+    it('does not trigger refresh when disabled', async () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh, disabled: true }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 100));
+      });
+
+      await act(async () => {
+        mockElement.dispatchEvent(createTouchEvent('touchend', 100));
+        await Promise.resolve(); // Flush microtasks for async state updates
+      });
+
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('configuration', () => {
+    it('uses default threshold of 80px', async () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      // Just under default threshold (with resistance)
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 70));
+      });
+
+      await act(async () => {
+        mockElement.dispatchEvent(createTouchEvent('touchend', 70));
+        await Promise.resolve(); // Flush microtasks for async state updates
+      });
+
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+
+    it('respects custom threshold', async () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      // With threshold 50 and default resistance 0.5, need to pull 100+ pixels
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold: 50 }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      // Past custom threshold: 120 * 0.5 = 60 > 50
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 120));
+      });
+
+      await act(async () => {
+        mockElement.dispatchEvent(createTouchEvent('touchend', 120));
+        await Promise.resolve(); // Flush microtasks for async state updates
+      });
+
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies resistance factor to pull distance', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh, resistance: 0.5 }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 100));
+      });
+
+      // With 0.5 resistance, 100px pull should result in ~50px pull distance
+      expect(result.current.pullDistance).toBeLessThan(100);
+    });
+  });
+
+  describe('concurrent refresh prevention', () => {
+    it('does not trigger multiple refreshes while one is in progress', async () => {
+      let resolveRefresh: () => void;
+      const onRefresh = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+
+      // With threshold 80 and default resistance 0.5, need to pull 160+ pixels
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold: 80 }));
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      // First pull and release: 180 * 0.5 = 90 > 80
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 180));
+      });
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchend', 180));
+      });
+
+      expect(result.current.isRefreshing).toBe(true);
+
+      // Try to trigger another refresh while first is in progress
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchstart', 0));
+      });
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchmove', 180));
+      });
+      act(() => {
+        mockElement.dispatchEvent(createTouchEvent('touchend', 180));
+      });
+
+      // Should only have been called once
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+
+      // Resolve first refresh
+      await act(async () => {
+        resolveRefresh();
+        await Promise.resolve(); // Flush microtasks for async state updates
+      });
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes event listeners when element is detached', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+      const removeEventListenerSpy = vi.spyOn(mockElement, 'removeEventListener');
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      // Detach by passing null
+      act(() => {
+        result.current.containerRef(null);
+      });
+
+      expect(removeEventListenerSpy).toHaveBeenCalled();
+    });
+
+    it('removes event listeners on unmount', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result, unmount } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+      const removeEventListenerSpy = vi.spyOn(mockElement, 'removeEventListener');
+
+      act(() => {
+        result.current.containerRef(mockElement);
+      });
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('external isRefreshing control', () => {
+    it('respects external isRefreshing prop', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+      const { result, rerender } = renderHook(
+        ({ isRefreshing }) => usePullToRefresh({ onRefresh, isRefreshing }),
+        { initialProps: { isRefreshing: false } }
+      );
+
+      expect(result.current.isRefreshing).toBe(false);
+
+      rerender({ isRefreshing: true });
+
+      expect(result.current.isRefreshing).toBe(true);
+    });
+  });
+});

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -494,3 +494,10 @@ export type {
   UseSummaryExpansionOptions,
   UseSummaryExpansionReturn,
 } from './useSummaryExpansion';
+
+// Pull-to-refresh hook (NEM-2970)
+export { usePullToRefresh, default as usePullToRefreshDefault } from './usePullToRefresh';
+export type {
+  PullToRefreshOptions,
+  PullToRefreshReturn,
+} from './usePullToRefresh';

--- a/frontend/src/hooks/usePullToRefresh.ts
+++ b/frontend/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,332 @@
+/**
+ * usePullToRefresh - Hook for detecting pull-to-refresh gestures on mobile
+ *
+ * Detects pull-down gestures at the top of a scrollable container to trigger
+ * a refresh action. Provides visual feedback state for pull progress.
+ *
+ * Features:
+ * - Only activates when at the top of scroll container
+ * - Configurable threshold and resistance
+ * - Prevents multiple concurrent refreshes
+ * - Provides pull progress for visual feedback
+ *
+ * @see NEM-2970
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface PullToRefreshOptions {
+  /**
+   * Callback function when refresh is triggered.
+   * Should return a Promise that resolves when refresh is complete.
+   */
+  onRefresh: () => Promise<void>;
+
+  /**
+   * Minimum pull distance in pixels to trigger refresh.
+   * @default 80
+   */
+  threshold?: number;
+
+  /**
+   * Resistance factor applied to pull distance (0-1).
+   * Lower values make pulling feel heavier.
+   * @default 0.5
+   */
+  resistance?: number;
+
+  /**
+   * Whether pull-to-refresh is disabled.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * External control of refreshing state.
+   * Useful when refresh state is managed externally (e.g., by React Query).
+   */
+  isRefreshing?: boolean;
+}
+
+export interface PullToRefreshReturn {
+  /**
+   * Ref callback to attach to the scrollable container element.
+   */
+  containerRef: (element: HTMLElement | null) => void;
+
+  /**
+   * Whether the user is currently pulling down.
+   */
+  isPulling: boolean;
+
+  /**
+   * Whether a refresh is currently in progress.
+   */
+  isRefreshing: boolean;
+
+  /**
+   * Current pull distance in pixels (after resistance applied).
+   */
+  pullDistance: number;
+
+  /**
+   * Pull progress as a ratio (0-1) of pullDistance to threshold.
+   */
+  pullProgress: number;
+}
+
+interface TouchStartState {
+  y: number;
+  scrollTop: number;
+}
+
+/**
+ * Custom hook that detects pull-to-refresh gestures on a scrollable container.
+ *
+ * @param options - Configuration options for pull-to-refresh
+ * @returns Object containing ref callback and state for visual feedback
+ *
+ * @example
+ * ```tsx
+ * const { containerRef, isPulling, isRefreshing, pullProgress } = usePullToRefresh({
+ *   onRefresh: async () => {
+ *     await refetchData();
+ *   },
+ *   threshold: 80,
+ * });
+ *
+ * return (
+ *   <div ref={containerRef}>
+ *     {isPulling && <PullIndicator progress={pullProgress} />}
+ *     {isRefreshing && <Spinner />}
+ *     <Content />
+ *   </div>
+ * );
+ * ```
+ */
+export function usePullToRefresh({
+  onRefresh,
+  threshold = 80,
+  resistance = 0.5,
+  disabled = false,
+  isRefreshing: externalIsRefreshing,
+}: PullToRefreshOptions): PullToRefreshReturn {
+  const [isPulling, setIsPulling] = useState(false);
+  const [internalIsRefreshing, setInternalIsRefreshing] = useState(false);
+  const [pullDistance, setPullDistance] = useState(0);
+
+  // Track touch start position
+  const touchStartRef = useRef<TouchStartState | null>(null);
+  // Track current element
+  const elementRef = useRef<HTMLElement | null>(null);
+  // Track if refresh is in progress (ref for sync access in event handlers)
+  const refreshingRef = useRef(false);
+  // Track current pull distance in ref for sync access in touchend handler
+  const pullDistanceRef = useRef(0);
+
+  // Use external isRefreshing if provided, otherwise use internal state
+  const isRefreshing = externalIsRefreshing ?? internalIsRefreshing;
+
+  // Store latest callbacks in refs
+  const onRefreshRef = useRef(onRefresh);
+  useEffect(() => {
+    onRefreshRef.current = onRefresh;
+  }, [onRefresh]);
+
+  // Calculate pull progress
+  const pullProgress = Math.min(pullDistance / threshold, 1);
+
+  const handleTouchStart = useCallback(
+    (e: TouchEvent) => {
+      if (disabled || refreshingRef.current) {
+        return;
+      }
+
+      const touch = e.touches[0];
+      if (!touch) {
+        return;
+      }
+
+      const element = elementRef.current;
+      const scrollTop = element?.scrollTop ?? 0;
+
+      touchStartRef.current = {
+        y: touch.clientY,
+        scrollTop,
+      };
+    },
+    [disabled]
+  );
+
+  const handleTouchMove = useCallback(
+    (e: TouchEvent) => {
+      if (disabled || refreshingRef.current) {
+        return;
+      }
+
+      const touchStart = touchStartRef.current;
+      if (!touchStart) {
+        return;
+      }
+
+      const touch = e.touches[0];
+      if (!touch) {
+        return;
+      }
+
+      const element = elementRef.current;
+      const currentScrollTop = element?.scrollTop ?? 0;
+
+      // Only allow pull when at the top of scroll container
+      if (currentScrollTop > 0) {
+        // Reset state if we scrolled away from top
+        if (isPulling) {
+          setIsPulling(false);
+          setPullDistance(0);
+          pullDistanceRef.current = 0;
+        }
+        return;
+      }
+
+      // Calculate raw delta
+      const deltaY = touch.clientY - touchStart.y;
+
+      // Only respond to downward pull
+      if (deltaY <= 0) {
+        if (isPulling) {
+          setIsPulling(false);
+          setPullDistance(0);
+          pullDistanceRef.current = 0;
+        }
+        return;
+      }
+
+      // Apply resistance
+      const resistedDistance = deltaY * resistance;
+
+      setIsPulling(true);
+      setPullDistance(resistedDistance);
+      pullDistanceRef.current = resistedDistance;
+
+      // Prevent default scrolling behavior during pull
+      if (resistedDistance > 0) {
+        e.preventDefault();
+      }
+    },
+    [disabled, isPulling, resistance]
+  );
+
+  const handleTouchEnd = useCallback(async () => {
+    if (disabled || refreshingRef.current) {
+      touchStartRef.current = null;
+      return;
+    }
+
+    // Use ref value for sync access (state may be stale in event handler)
+    const currentPullDistance = pullDistanceRef.current;
+    const shouldRefresh = currentPullDistance >= threshold;
+
+    // Reset touch tracking
+    touchStartRef.current = null;
+
+    if (shouldRefresh) {
+      // Trigger refresh
+      refreshingRef.current = true;
+      setInternalIsRefreshing(true);
+
+      try {
+        await onRefreshRef.current();
+      } finally {
+        refreshingRef.current = false;
+        setInternalIsRefreshing(false);
+      }
+    }
+
+    // Reset pull state
+    setIsPulling(false);
+    setPullDistance(0);
+    pullDistanceRef.current = 0;
+  }, [disabled, threshold]);
+
+  // Store latest handlers in refs for stable event listeners
+  const handleTouchStartRef = useRef(handleTouchStart);
+  const handleTouchMoveRef = useRef(handleTouchMove);
+  const handleTouchEndRef = useRef(handleTouchEnd);
+
+  useEffect(() => {
+    handleTouchStartRef.current = handleTouchStart;
+  }, [handleTouchStart]);
+
+  useEffect(() => {
+    handleTouchMoveRef.current = handleTouchMove;
+  }, [handleTouchMove]);
+
+  useEffect(() => {
+    handleTouchEndRef.current = handleTouchEnd;
+  }, [handleTouchEnd]);
+
+  // Stable event handlers that delegate to refs
+  const stableTouchStart = useCallback((e: TouchEvent) => {
+    handleTouchStartRef.current(e);
+  }, []);
+
+  const stableTouchMove = useCallback((e: TouchEvent) => {
+    handleTouchMoveRef.current(e);
+  }, []);
+
+  const stableTouchEnd = useCallback(() => {
+    void handleTouchEndRef.current();
+  }, []);
+
+  // Ref callback - now with stable handlers
+  const containerRef = useCallback(
+    (element: HTMLElement | null) => {
+      // Remove listeners from previous element
+      if (elementRef.current) {
+        elementRef.current.removeEventListener('touchstart', stableTouchStart);
+        elementRef.current.removeEventListener(
+          'touchmove',
+          stableTouchMove as EventListener
+        );
+        elementRef.current.removeEventListener('touchend', stableTouchEnd);
+      }
+
+      // Store new element
+      elementRef.current = element;
+
+      // Add listeners to new element
+      if (element && !disabled) {
+        element.addEventListener('touchstart', stableTouchStart, { passive: true });
+        element.addEventListener('touchmove', stableTouchMove as EventListener, {
+          passive: false,
+        });
+        element.addEventListener('touchend', stableTouchEnd, { passive: true });
+      }
+    },
+    [stableTouchStart, stableTouchMove, stableTouchEnd, disabled]
+  );
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (elementRef.current) {
+        elementRef.current.removeEventListener('touchstart', stableTouchStart);
+        elementRef.current.removeEventListener(
+          'touchmove',
+          stableTouchMove as EventListener
+        );
+        elementRef.current.removeEventListener('touchend', stableTouchEnd);
+      }
+    };
+  }, [stableTouchStart, stableTouchMove, stableTouchEnd]);
+
+  return {
+    containerRef,
+    isPulling,
+    isRefreshing,
+    pullDistance,
+    pullProgress,
+  };
+}
+
+export default usePullToRefresh;


### PR DESCRIPTION
## Summary
- Add `usePullToRefresh` hook for detecting pull-down gestures on mobile
- Add `PullToRefresh` component with visual loading indicator
- Export new hook from hooks index

## Test plan
- [x] Unit tests for usePullToRefresh hook
- [x] Unit tests for PullToRefresh component
- [ ] Manual testing on mobile device

🤖 Generated with [Claude Code](https://claude.com/claude-code)