### PR TITLE
fix: update Sidebar test to expect 16 nav items

### DIFF
--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -145,7 +145,7 @@ describe('Sidebar', () => {
   it('renders all 15 navigation items', () => {
     renderWithRouter();
     const links = screen.getAllByRole('link');
-    expect(links).toHaveLength(15);
+    expect(links).toHaveLength(16);
   });
 
   it('jobs link has correct href', () => {
@@ -387,7 +387,7 @@ describe('Sidebar', () => {
     });
 
     it('exports navItems as flattened list of all items', () => {
-      expect(navItems).toHaveLength(15);
+      expect(navItems).toHaveLength(16);
       expect(navItems.some((item) => item.id === 'dashboard')).toBe(true);
       expect(navItems.some((item) => item.id === 'settings')).toBe(true);
       expect(navItems.some((item) => item.id === 'data')).toBe(true);


### PR DESCRIPTION
## Summary

Quick fix for Sidebar test assertion after the integration gaps PR added the Data Management page.

- Updated `navItems` length assertion from 15 to 16
- Updated `links` length assertion from 15 to 16

The nav structure is now: 4 groups × 4 items = 16 total items.

## Test Plan
- [x] `npm test -- Sidebar.test --run` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)