### PR TITLE
fix(ci): update dorny/paths-filter to v3.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Detect file changes
-        uses: dorny/paths-filter@17de8ba7ec422df3a8d66b68b31e3e8fdd27cbed # v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Summary
- Updates dorny/paths-filter action from unavailable SHA to v3.0.2
- The previous SHA `17de8ba7ec422df3a8d66b68b31e3e8fdd27cbed` was causing CI failures

## Test plan
- [x] CI workflow runs successfully with new SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)