### PR TITLE
docs: add Security and Dataflows links to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,16 @@ docker compose up -d
 
 ![AI Pipeline Flow](docs/images/flow-ai-pipeline.png)
 
+**Detailed Documentation:**
+
+| Hub                                                                  | Description                                |
+| -------------------------------------------------------------------- | ------------------------------------------ |
+| [Architecture Hub](docs/architecture/README.md)                      | Complete system architecture documentation |
+| [Security](docs/architecture/security/README.md)                     | Input validation, data protection, OWASP   |
+| [Dataflows](docs/architecture/dataflows/README.md)                   | End-to-end data traces, pipeline timing    |
+| [Detection Pipeline](docs/architecture/detection-pipeline/README.md) | RT-DETRv2 integration, image processing    |
+| [AI Orchestration](docs/architecture/ai-orchestration/README.md)     | Nemotron LLM, batch processing             |
+
 ---
 
 <details>

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,13 +57,15 @@ Every directory contains an `AGENTS.md` file for AI assistant navigation. Start 
 
 ## Technical Documentation
 
-| Category                | Location                                                   | Description                                  |
-| ----------------------- | ---------------------------------------------------------- | -------------------------------------------- |
-| **System Architecture** | [architecture/overview.md](architecture/overview.md)       | High-level system design and components      |
-| **AI Pipeline**         | [architecture/ai-pipeline.md](architecture/ai-pipeline.md) | Detection and analysis pipeline architecture |
-| **Data Model**          | [architecture/data-model.md](architecture/data-model.md)   | Database schema and relationships            |
-| **Real-time System**    | [architecture/real-time.md](architecture/real-time.md)     | WebSocket and event streaming                |
-| **Decision Records**    | [decisions/README.md](decisions/README.md)                 | Architectural Decision Records (ADRs)        |
+| Category                | Location                                                             | Description                                         |
+| ----------------------- | -------------------------------------------------------------------- | --------------------------------------------------- |
+| **System Architecture** | [architecture/overview.md](architecture/overview.md)                 | High-level system design and components             |
+| **AI Pipeline**         | [architecture/ai-pipeline.md](architecture/ai-pipeline.md)           | Detection and analysis pipeline architecture        |
+| **Data Model**          | [architecture/data-model.md](architecture/data-model.md)             | Database schema and relationships                   |
+| **Real-time System**    | [architecture/real-time.md](architecture/real-time.md)               | WebSocket and event streaming                       |
+| **Security**            | [architecture/security/README.md](architecture/security/README.md)   | Input validation, data protection, network security |
+| **Dataflows**           | [architecture/dataflows/README.md](architecture/dataflows/README.md) | End-to-end data traces, pipeline timing             |
+| **Decision Records**    | [decisions/README.md](decisions/README.md)                           | Architectural Decision Records (ADRs)               |
 
 ### AI Pipeline Quality Assurance
 


### PR DESCRIPTION
## Summary

- Add Security and Dataflows hub links to `docs/README.md` Technical Documentation table
- Add detailed architecture documentation table to main `README.md` with links to:
  - Architecture Hub (main documentation)
  - Security (input validation, data protection, OWASP)
  - Dataflows (end-to-end data traces, pipeline timing)
  - Detection Pipeline (RT-DETRv2 integration)
  - AI Orchestration (Nemotron LLM, batch processing)

## Test plan

- [x] Links point to existing documentation files
- [x] Markdown table formatting is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)