### PR TITLE
docs: link generated images to security and dataflows documentation

### DIFF
--- a/docs/architecture/dataflows/README.md
+++ b/docs/architecture/dataflows/README.md
@@ -2,6 +2,8 @@
 
 This hub documents the end-to-end data flows within the Home Security Intelligence system. Each document traces data through specific pathways, including timing information, error handling, and recovery mechanisms.
 
+![Dataflows Overview](../../images/architecture/dataflows/hero-dataflows.png)
+
 ## End-to-End Flow Summary
 
 ```

--- a/docs/architecture/dataflows/api-request-flow.md
+++ b/docs/architecture/dataflows/api-request-flow.md
@@ -2,6 +2,8 @@
 
 This document describes the complete lifecycle of a REST API request, from HTTP reception through response, including middleware processing, route handling, and error responses.
 
+![API Request Flow](../../images/architecture/dataflows/flow-api-request.png)
+
 ## Request Flow Sequence Diagram
 
 ```mermaid
@@ -242,6 +244,8 @@ async def get_queue_stats(
 ```
 
 ## Request Processing Timeline
+
+![Request Timing](../../images/architecture/dataflows/technical-request-timing.png)
 
 ```
 Time 0ms:   Request received by Uvicorn

--- a/docs/architecture/dataflows/batch-aggregation-flow.md
+++ b/docs/architecture/dataflows/batch-aggregation-flow.md
@@ -2,6 +2,8 @@
 
 This document describes the detection batching mechanism, including timing windows, Redis data structures, and batch lifecycle management.
 
+![Batch Aggregation Overview](../../images/architecture/dataflows/flow-batch-aggregation.png)
+
 ## Batch Aggregation Overview
 
 **Source:** `backend/services/batch_aggregator.py:1-40`
@@ -18,6 +20,8 @@ This document describes the detection batching mechanism, including timing windo
 ```
 
 ## Timing Diagram
+
+![Batch Timing](../../images/architecture/dataflows/flow-batch-timing.png)
 
 ```
 Timeline for Camera "front_door"
@@ -398,6 +402,8 @@ async def get_memory_pressure_level() -> Any:
 ```
 
 ## Batch Lifecycle State Diagram
+
+![Batch States](../../images/architecture/dataflows/technical-batch-states.png)
 
 ```mermaid
 stateDiagram-v2

--- a/docs/architecture/dataflows/enrichment-pipeline.md
+++ b/docs/architecture/dataflows/enrichment-pipeline.md
@@ -2,6 +2,8 @@
 
 This document describes the enrichment pipeline that enhances detections with additional AI-generated context before LLM analysis.
 
+![Enrichment Pipeline Overview](../../images/architecture/dataflows/flow-enrichment-pipeline.png)
+
 ## Pipeline Overview
 
 **Source:** `backend/services/enrichment_pipeline.py:1-17`
@@ -301,6 +303,8 @@ from backend.services.xclip_loader import (
 | **Pet Classifier**         | Animal crop  | Species/breed       | Pet identification       |
 
 ## Enrichment Flow by Detection Type
+
+![Enrichment Routing](../../images/architecture/dataflows/technical-enrichment-routing.png)
 
 ### Vehicle Detections
 

--- a/docs/architecture/dataflows/error-recovery-flow.md
+++ b/docs/architecture/dataflows/error-recovery-flow.md
@@ -2,6 +2,8 @@
 
 This document describes the error handling and recovery mechanisms used throughout the system, including circuit breakers, retry logic, and graceful degradation.
 
+![Error Recovery Overview](../../images/architecture/dataflows/flow-error-recovery.png)
+
 ## Circuit Breaker Pattern
 
 **Source:** `backend/services/circuit_breaker.py:1-42`
@@ -30,6 +32,8 @@ Features:
 ```
 
 ## Circuit Breaker State Machine
+
+![Circuit Breaker](../../images/architecture/dataflows/flow-circuit-breaker.png)
 
 ```mermaid
 stateDiagram-v2

--- a/docs/architecture/dataflows/event-lifecycle.md
+++ b/docs/architecture/dataflows/event-lifecycle.md
@@ -2,6 +2,8 @@
 
 This document describes the complete lifecycle of a security event from creation through archival, including state transitions, data transformations, and retention policies.
 
+![Event Lifecycle Overview](../../images/architecture/dataflows/flow-event-lifecycle.png)
+
 ## Event State Machine
 
 ```mermaid
@@ -17,6 +19,8 @@ stateDiagram-v2
 ```
 
 ## Event Creation
+
+![Event States](../../images/architecture/dataflows/concept-event-states.png)
 
 **Source:** `backend/services/nemotron_analyzer.py:6-17`
 

--- a/docs/architecture/dataflows/image-to-event.md
+++ b/docs/architecture/dataflows/image-to-event.md
@@ -2,6 +2,8 @@
 
 This document traces the complete journey of a camera image from upload to security event creation, including all processing stages, timing, and error handling.
 
+![Image to Event Overview](../../images/architecture/dataflows/flow-image-to-event.png)
+
 ## Flow Sequence Diagram
 
 ```mermaid
@@ -352,6 +354,8 @@ After successful LLM analysis, an Event record is created in PostgreSQL with:
 **Buffer size:** 100 messages
 
 ## End-to-End Timing Summary
+
+![Image to Event Timing](../../images/architecture/dataflows/technical-image-to-event-timing.png)
 
 | Stage                | Typical Duration | Max Duration    |
 | -------------------- | ---------------- | --------------- |

--- a/docs/architecture/dataflows/llm-analysis-flow.md
+++ b/docs/architecture/dataflows/llm-analysis-flow.md
@@ -2,6 +2,8 @@
 
 This document describes the Nemotron LLM analysis process, including prompt construction, request handling, retry logic, and response parsing.
 
+![LLM Analysis Overview](../../images/architecture/dataflows/flow-llm-analysis.png)
+
 ## Analysis Flow Overview
 
 **Source:** `backend/services/nemotron_analyzer.py:1-28`
@@ -166,6 +168,8 @@ Request 5: WAIT (count: 0) -> Acquire when available -> Process -> Release
 | Validation error         | No        | Invalid response data   |
 
 ## Prompt Construction
+
+![Prompt Construction](../../images/architecture/dataflows/concept-prompt-construction.png)
 
 ### Prompt Templates
 

--- a/docs/architecture/dataflows/startup-shutdown-flow.md
+++ b/docs/architecture/dataflows/startup-shutdown-flow.md
@@ -2,6 +2,8 @@
 
 This document describes the application lifecycle, including startup initialization sequence, signal handling, and graceful shutdown procedures.
 
+![Startup Shutdown Overview](../../images/architecture/dataflows/flow-startup.png)
+
 ## Application Lifecycle Overview
 
 **Source:** `backend/main.py:461-479`
@@ -314,6 +316,8 @@ def get_shutdown_event() -> asyncio.Event:
 ```
 
 ## Shutdown Sequence
+
+![Shutdown Sequence](../../images/architecture/dataflows/flow-shutdown-sequence.png)
 
 ### Graceful Shutdown Order
 

--- a/docs/architecture/dataflows/websocket-message-flow.md
+++ b/docs/architecture/dataflows/websocket-message-flow.md
@@ -2,6 +2,8 @@
 
 This document describes the complete WebSocket message flow from connection establishment through event delivery, including authentication, subscription management, heartbeat, and message sequencing.
 
+![WebSocket Message Flow Overview](../../images/architecture/dataflows/flow-websocket-message.png)
+
 ## Connection Sequence Diagram
 
 ```mermaid
@@ -129,6 +131,8 @@ async def validate_websocket_message(
 | `VALIDATION_ERROR`       | Data validation failed      |
 
 ## Message Types
+
+![WebSocket Message Types](../../images/architecture/dataflows/concept-websocket-message-types.png)
 
 **Source:** `backend/api/routes/websocket.py:140-231`
 
@@ -346,6 +350,8 @@ ws.onmessage = (event) => {
 ```
 
 ## Event Broadcasting
+
+![WebSocket Broadcast](../../images/architecture/dataflows/flow-websocket-broadcast.png)
 
 **Source:** `backend/services/event_broadcaster.py:335-400`
 

--- a/docs/architecture/security/README.md
+++ b/docs/architecture/security/README.md
@@ -2,6 +2,8 @@
 
 > Security model, input validation, data protection, and hardening guidelines for the AI-powered home security monitoring system
 
+![Security Architecture Overview](../../images/architecture/security/hero-security.png)
+
 ## Overview
 
 This hub documents the security considerations and implementations for the Home Security Intelligence system. The system is designed for **single-user, trusted network deployment** - it operates on a local network without exposure to the public internet.
@@ -18,6 +20,8 @@ While the system does not require authentication by default (configurable via `A
 | Camera data is sensitive | Path traversal protection on all media endpoints |
 
 ## Security Architecture
+
+![Security Middleware Stack](../../images/architecture/security/flow-security-middleware.png)
 
 ```mermaid
 flowchart TB
@@ -98,6 +102,8 @@ flowchart TB
 | Request Recording      | `REQUEST_RECORDING_ENABLED` | `false` |
 
 ## OWASP Top 10 Coverage
+
+![OWASP Coverage](../../images/architecture/security/concept-owasp-coverage.png)
 
 | OWASP Category                | Mitigation                                  | Status      |
 | ----------------------------- | ------------------------------------------- | ----------- |

--- a/docs/architecture/security/authentication-roadmap.md
+++ b/docs/architecture/security/authentication-roadmap.md
@@ -2,6 +2,8 @@
 
 > Future authentication implementation considerations for multi-user and remote access scenarios
 
+![Authentication Roadmap Overview](../../images/architecture/security/flow-auth-roadmap.png)
+
 ## Key Files
 
 - `backend/core/config.py:1090-1098` - Current API key authentication settings
@@ -15,6 +17,8 @@ The Home Security Intelligence system is currently designed for **single-user, t
 This document outlines the current authentication state and provides a roadmap for future enhancements if multi-user or remote access requirements emerge.
 
 ## Current Authentication State
+
+![API Key Authentication](../../images/architecture/security/flow-api-key-auth.png)
 
 ### API Key Authentication (Optional)
 

--- a/docs/architecture/security/data-protection.md
+++ b/docs/architecture/security/data-protection.md
@@ -2,6 +2,8 @@
 
 > Sensitive data handling, image storage security, and log sanitization
 
+![Data Protection Overview](../../images/architecture/security/technical-data-protection.png)
+
 ## Key Files
 
 - `backend/api/routes/media.py:42-124` - Secure media serving with path validation
@@ -21,6 +23,8 @@ The Home Security Intelligence system handles sensitive data including camera im
 4. **Error Message Filtering** - Removing internal paths and credentials from responses
 
 ## Image and Video Storage Security
+
+![Data Protection Zones](../../images/architecture/security/concept-data-protection-zones.png)
 
 ### Path Traversal Protection
 
@@ -162,6 +166,8 @@ api_keys: list[str] = Field(
 | No plaintext storage   | Keys hashed immediately on load    |
 
 ## Log Sanitization
+
+![Log Sanitization](../../images/architecture/security/concept-log-sanitization.png)
 
 ### Error Message Sanitization
 

--- a/docs/architecture/security/input-validation.md
+++ b/docs/architecture/security/input-validation.md
@@ -2,6 +2,8 @@
 
 > Pydantic validation patterns, SQL injection prevention, and request sanitization
 
+![Input Validation Overview](../../images/architecture/security/flow-input-validation.png)
+
 ## Key Files
 
 - `backend/api/schemas/camera.py:36-137` - Camera input validation with path traversal prevention
@@ -24,6 +26,8 @@ The Home Security Intelligence system uses a layered input validation approach:
 This follows OWASP guidelines for input validation: validate on the server side, use allowlists where possible, and sanitize output.
 
 ## Pydantic Schema Validation
+
+![Pydantic Validation](../../images/architecture/security/technical-pydantic-validation.png)
 
 ### Field Constraints
 
@@ -174,6 +178,8 @@ def _validate_polygon_geometry(coords: list[list[float]]) -> list[list[float]]:
 
 ## SQL Injection Prevention
 
+![SQL Injection Prevention](../../images/architecture/security/concept-sql-injection-prevention.png)
+
 ### SQLAlchemy ORM Usage
 
 The system uses SQLAlchemy ORM exclusively, which provides automatic parameterization:
@@ -269,7 +275,7 @@ Sensitive data is redacted from error messages:
 
 ```python
 # From backend/core/sanitization.py:159-169
-# Pattern matches: protocol://user:pass@host
+# Pattern matches: protocol://user:pass@host  # pragma: allowlist secret
 url_credentials_pattern = re.compile(
     r"([a-zA-Z][a-zA-Z0-9+.-]*://)?([^:@\s/]+):([^@\s/]+)@([^\s]+)", re.IGNORECASE  # pragma: allowlist secret
 )

--- a/docs/architecture/security/network-security.md
+++ b/docs/architecture/security/network-security.md
@@ -2,6 +2,8 @@
 
 > CORS configuration, trusted network assumptions, and SSRF protection
 
+![Network Security Overview](../../images/architecture/security/concept-network-zones.png)
+
 ## Key Files
 
 - `backend/core/config.py:572-585` - CORS origins configuration
@@ -62,6 +64,8 @@ flowchart TB
 
 ## CORS Configuration
 
+![CORS Configuration](../../images/architecture/security/technical-cors-configuration.png)
+
 ### Default Origins
 
 CORS is configured to allow common local development origins:
@@ -118,6 +122,8 @@ export CORS_ORIGINS='["http://192.168.1.100:3000","http://dashboard.local:3000"]
 ```
 
 ## SSRF Protection
+
+![SSRF Protection](../../images/architecture/security/technical-ssrf-protection.png)
 
 ### Overview
 

--- a/docs/architecture/security/security-headers.md
+++ b/docs/architecture/security/security-headers.md
@@ -2,6 +2,8 @@
 
 > HTTP security headers, Content Security Policy, and defense-in-depth configuration
 
+![Security Headers Overview](../../images/architecture/security/technical-security-headers.png)
+
 ## Key Files
 
 - `backend/api/middleware/security_headers.py` - Security headers middleware implementation
@@ -144,6 +146,8 @@ export HSTS_PRELOAD=true
 ```
 
 ## Content Security Policy (CSP)
+
+![Content Security Policy](../../images/architecture/security/concept-csp-policy.png)
 
 ### Backend CSP Policy
 


### PR DESCRIPTION
## Summary

- Link generated images to their corresponding markdown documentation files
- Updated 16 markdown files across security and dataflows architecture hubs
- Added 36 image references total

### Security Hub (6 files, 16 image references)
- `README.md`: hero, middleware flow, OWASP coverage
- `input-validation.md`: flow, pydantic, SQL injection prevention
- `data-protection.md`: overview, zones, log sanitization
- `network-security.md`: zones, SSRF, CORS configuration
- `security-headers.md`: overview, CSP policy
- `authentication-roadmap.md`: roadmap, API key auth

### Dataflows Hub (10 files, 20 image references)
- `README.md`: hero overview
- `api-request-flow.md`: flow, timing
- `batch-aggregation-flow.md`: flow, timing, states
- `enrichment-pipeline.md`: flow, routing
- `error-recovery-flow.md`: recovery, circuit breaker
- `event-lifecycle.md`: lifecycle, states
- `image-to-event.md`: flow, timing
- `llm-analysis-flow.md`: analysis, prompt construction
- `startup-shutdown-flow.md`: startup, shutdown sequence
- `websocket-message-flow.md`: flow, types, broadcast

## Test plan

- [x] Verify image paths match existing images in docs/images/architecture/security/ and docs/images/architecture/dataflows/
- [x] Commit passes pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)