### PR TITLE
feat(pwa): implement offline caching with service worker registration (NEM-3675)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
   ChunkLoadErrorBoundary,
   ErrorBoundary,
   NavigationTracker,
+  OfflineStatusIndicator,
   PageTransition,
   ProductTour,
   RateLimitIndicator,
@@ -183,6 +184,8 @@ export default function App() {
           <RetryingIndicator />
           {/* PWA install prompt - shows after engagement criteria met */}
           <InstallPrompt />
+          {/* PWA offline status indicator - shows when offline (NEM-3675) */}
+          <OfflineStatusIndicator position="bottom-left" variant="banner" reloadOnRetry />
         </AnnouncementProvider>
         {/* React Query DevTools - only shown in development */}
         <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-right" />

--- a/frontend/src/components/common/OfflineIndicator.test.tsx
+++ b/frontend/src/components/common/OfflineIndicator.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Tests for OfflineIndicator component
+ * @see NEM-3675 - PWA Offline Caching
+ */
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import OfflineIndicator from './OfflineIndicator';
+
+describe('OfflineIndicator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('visibility', () => {
+    it('does not render when online (isOffline=false)', () => {
+      render(<OfflineIndicator isOffline={false} />);
+      expect(screen.queryByTestId('offline-indicator')).not.toBeInTheDocument();
+    });
+
+    it('renders when offline (isOffline=true)', () => {
+      render(<OfflineIndicator isOffline={true} />);
+      expect(screen.getByTestId('offline-indicator')).toBeInTheDocument();
+    });
+
+    it('respects show prop override', () => {
+      // Show when online via show prop
+      render(<OfflineIndicator isOffline={false} show={true} />);
+      expect(screen.getByTestId('offline-indicator')).toBeInTheDocument();
+    });
+
+    it('hides when show=false even if offline', () => {
+      render(<OfflineIndicator isOffline={true} show={false} />);
+      expect(screen.queryByTestId('offline-indicator')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('banner variant', () => {
+    it('displays "Offline Mode" text', () => {
+      render(<OfflineIndicator isOffline={true} variant="banner" />);
+      expect(screen.getByText('Offline Mode')).toBeInTheDocument();
+    });
+
+    it('displays cached events count', () => {
+      render(<OfflineIndicator isOffline={true} variant="banner" cachedEventsCount={15} />);
+      expect(screen.getByText(/15 events cached/)).toBeInTheDocument();
+    });
+
+    it('displays last online time', () => {
+      const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+      render(<OfflineIndicator isOffline={true} variant="banner" lastOnlineAt={fiveMinutesAgo} />);
+      expect(screen.getByText(/5 minutes ago/)).toBeInTheDocument();
+    });
+
+    it('shows retry button when onRetry provided', () => {
+      const onRetry = vi.fn();
+      render(<OfflineIndicator isOffline={true} variant="banner" onRetry={onRetry} />);
+      const retryButton = screen.getByRole('button', { name: /retry/i });
+      expect(retryButton).toBeInTheDocument();
+      fireEvent.click(retryButton);
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows dismiss button when dismissible', () => {
+      render(<OfflineIndicator isOffline={true} variant="banner" dismissible />);
+      expect(screen.getByRole('button', { name: /dismiss/i })).toBeInTheDocument();
+    });
+
+    it('hides on dismiss', () => {
+      const onDismiss = vi.fn();
+      render(<OfflineIndicator isOffline={true} variant="banner" dismissible onDismiss={onDismiss} />);
+      const dismissButton = screen.getByRole('button', { name: /dismiss/i });
+      fireEvent.click(dismissButton);
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId('offline-indicator')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('badge variant', () => {
+    it('renders as a badge', () => {
+      render(<OfflineIndicator isOffline={true} variant="badge" />);
+      expect(screen.getByText('Offline')).toBeInTheDocument();
+    });
+
+    it('shows cached count in badge', () => {
+      render(<OfflineIndicator isOffline={true} variant="badge" cachedEventsCount={5} />);
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+  });
+
+  describe('minimal variant', () => {
+    it('renders as minimal icon', () => {
+      render(<OfflineIndicator isOffline={true} variant="minimal" />);
+      const indicator = screen.getByTestId('offline-indicator');
+      expect(indicator).toHaveAttribute('aria-label', 'Offline');
+    });
+  });
+
+  describe('position', () => {
+    it.each([
+      ['top-left', 'top-4 left-4'],
+      ['top-right', 'top-4 right-4'],
+      ['bottom-left', 'bottom-4 left-4'],
+      ['bottom-right', 'bottom-4 right-4'],
+      ['top', 'top-0 left-0 right-0'],
+      ['bottom', 'bottom-0 left-0 right-0'],
+    ] as const)('applies %s position classes', (position, expectedClasses) => {
+      render(<OfflineIndicator isOffline={true} position={position} />);
+      const indicator = screen.getByTestId('offline-indicator');
+      expectedClasses.split(' ').forEach((cls) => {
+        expect(indicator.className).toContain(cls);
+      });
+    });
+  });
+
+  describe('duration formatting', () => {
+    it('shows "Just now" for recent offline', () => {
+      const justNow = new Date();
+      render(<OfflineIndicator isOffline={true} variant="banner" lastOnlineAt={justNow} />);
+      expect(screen.getByText(/Just now/)).toBeInTheDocument();
+    });
+
+    it('shows minutes for < 1 hour', () => {
+      const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000);
+      render(<OfflineIndicator isOffline={true} variant="banner" lastOnlineAt={thirtyMinutesAgo} />);
+      expect(screen.getByText(/30 minutes ago/)).toBeInTheDocument();
+    });
+
+    it('shows hours for >= 1 hour', () => {
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      render(<OfflineIndicator isOffline={true} variant="banner" lastOnlineAt={twoHoursAgo} />);
+      expect(screen.getByText(/2 hours ago/)).toBeInTheDocument();
+    });
+
+    it('shows days for >= 24 hours', () => {
+      const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      render(<OfflineIndicator isOffline={true} variant="banner" lastOnlineAt={twoDaysAgo} />);
+      expect(screen.getByText(/2 days ago/)).toBeInTheDocument();
+    });
+
+    it('shows "Unknown duration" when lastOnlineAt is null', () => {
+      render(<OfflineIndicator isOffline={true} variant="banner" lastOnlineAt={null} />);
+      expect(screen.getByText(/Unknown duration/)).toBeInTheDocument();
+    });
+
+    it('updates duration every minute', () => {
+      const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+      render(<OfflineIndicator isOffline={true} variant="banner" lastOnlineAt={fiveMinutesAgo} />);
+      expect(screen.getByText(/5 minutes ago/)).toBeInTheDocument();
+
+      // Advance time by 1 minute
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+      expect(screen.getByText(/6 minutes ago/)).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has appropriate role for banner', () => {
+      render(<OfflineIndicator isOffline={true} variant="banner" />);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('has appropriate role for badge', () => {
+      render(<OfflineIndicator isOffline={true} variant="badge" />);
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('has aria-live attribute', () => {
+      render(<OfflineIndicator isOffline={true} variant="banner" />);
+      expect(screen.getByTestId('offline-indicator')).toHaveAttribute('aria-live');
+    });
+  });
+
+  describe('dismissed state reset', () => {
+    it('resets dismissed state when coming back online', () => {
+      const { rerender } = render(
+        <OfflineIndicator isOffline={true} variant="banner" dismissible />
+      );
+
+      // Dismiss the indicator
+      const dismissButton = screen.getByRole('button', { name: /dismiss/i });
+      fireEvent.click(dismissButton);
+      expect(screen.queryByTestId('offline-indicator')).not.toBeInTheDocument();
+
+      // Go online
+      rerender(<OfflineIndicator isOffline={false} variant="banner" dismissible />);
+
+      // Go offline again - should show again
+      rerender(<OfflineIndicator isOffline={true} variant="banner" dismissible />);
+      expect(screen.getByTestId('offline-indicator')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/common/OfflineIndicator.tsx
+++ b/frontend/src/components/common/OfflineIndicator.tsx
@@ -1,0 +1,316 @@
+/**
+ * OfflineIndicator component
+ *
+ * A compact offline status indicator with multiple variants:
+ * - banner: Full-width banner at top/bottom of screen
+ * - badge: Small floating badge
+ * - minimal: Icon-only indicator
+ *
+ * @module OfflineIndicator
+ * @see NEM-3675 - PWA Offline Caching
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+
+export type OfflineIndicatorPosition =
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'top'
+  | 'bottom';
+
+export type OfflineIndicatorVariant = 'banner' | 'badge' | 'minimal';
+
+export interface OfflineIndicatorProps {
+  /** Whether the app is currently offline */
+  isOffline: boolean;
+  /** Number of events cached for sync */
+  cachedEventsCount?: number;
+  /** When the app was last online */
+  lastOnlineAt?: Date | null;
+  /** Position of the indicator */
+  position?: OfflineIndicatorPosition;
+  /** Visual variant */
+  variant?: OfflineIndicatorVariant;
+  /** Whether the indicator can be dismissed */
+  dismissible?: boolean;
+  /** Callback when dismissed */
+  onDismiss?: () => void;
+  /** Callback when retry is clicked */
+  onRetry?: () => void;
+  /** Additional CSS classes */
+  className?: string;
+  /** Whether to show the indicator (can be controlled externally) */
+  show?: boolean;
+}
+
+/**
+ * Formats the duration since last online
+ * @param lastOnlineAt - The Date when the app was last online
+ * @returns Formatted duration string
+ */
+function formatOfflineDuration(lastOnlineAt: Date | null | undefined): string {
+  if (!lastOnlineAt) {
+    return 'Unknown duration';
+  }
+
+  const now = new Date();
+  const diffMs = now.getTime() - lastOnlineAt.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+
+  if (diffSeconds < 60) {
+    return 'Just now';
+  } else if (diffMinutes < 60) {
+    return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
+  } else if (diffHours < 24) {
+    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  } else {
+    const diffDays = Math.floor(diffHours / 24);
+    return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  }
+}
+
+/**
+ * Gets position classes for the indicator
+ */
+function getPositionClasses(position: OfflineIndicatorPosition): string {
+  const baseClasses = 'fixed z-50';
+  const positionMap: Record<OfflineIndicatorPosition, string> = {
+    'top-left': 'top-4 left-4',
+    'top-right': 'top-4 right-4',
+    'bottom-left': 'bottom-4 left-4',
+    'bottom-right': 'bottom-4 right-4',
+    top: 'top-0 left-0 right-0',
+    bottom: 'bottom-0 left-0 right-0',
+  };
+  return `${baseClasses} ${positionMap[position]}`;
+}
+
+/**
+ * Gets variant classes for the indicator
+ */
+function getVariantClasses(variant: OfflineIndicatorVariant): string {
+  const variantMap: Record<OfflineIndicatorVariant, string> = {
+    banner:
+      'bg-amber-500 dark:bg-amber-600 text-white px-4 py-3 shadow-lg flex items-center justify-between gap-4',
+    badge:
+      'bg-amber-500 dark:bg-amber-600 text-white px-3 py-2 rounded-lg shadow-lg flex items-center gap-2',
+    minimal:
+      'bg-amber-500 dark:bg-amber-600 text-white p-2 rounded-full shadow-lg',
+  };
+  return variantMap[variant];
+}
+
+/**
+ * OfflineIndicator - A compact offline status indicator
+ *
+ * Displays current offline status with optional:
+ * - Cached events count
+ * - Time since last online
+ * - Retry button
+ * - Dismiss functionality
+ */
+export default function OfflineIndicator({
+  isOffline,
+  cachedEventsCount = 0,
+  lastOnlineAt,
+  position = 'bottom-left',
+  variant = 'banner',
+  dismissible = false,
+  onDismiss,
+  onRetry,
+  className = '',
+  show,
+}: OfflineIndicatorProps): React.ReactElement | null {
+  const [dismissed, setDismissed] = useState(false);
+  const [offlineDuration, setOfflineDuration] = useState(() =>
+    formatOfflineDuration(lastOnlineAt)
+  );
+
+  // Update offline duration every minute
+  useEffect(() => {
+    if (!isOffline || !lastOnlineAt) return;
+
+    const interval = setInterval(() => {
+      setOfflineDuration(formatOfflineDuration(lastOnlineAt));
+    }, 60000);
+
+    return () => clearInterval(interval);
+  }, [isOffline, lastOnlineAt]);
+
+  // Reset dismissed state when coming back online
+  useEffect(() => {
+    if (!isOffline) {
+      setDismissed(false);
+    }
+  }, [isOffline]);
+
+  const handleDismiss = useCallback(() => {
+    setDismissed(true);
+    onDismiss?.();
+  }, [onDismiss]);
+
+  // Determine visibility
+  const shouldShow = show !== undefined ? show : isOffline;
+  if (!shouldShow || dismissed) {
+    return null;
+  }
+
+  const positionClasses = getPositionClasses(position);
+  const variantClasses = getVariantClasses(variant);
+
+  // Minimal variant - just an icon
+  if (variant === 'minimal') {
+    return (
+      <div
+        className={`${positionClasses} ${variantClasses} ${className}`}
+        role="status"
+        aria-live="polite"
+        aria-label="Offline"
+        data-testid="offline-indicator"
+      >
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3"
+          />
+        </svg>
+      </div>
+    );
+  }
+
+  // Badge variant - compact with essential info
+  if (variant === 'badge') {
+    return (
+      <div
+        className={`${positionClasses} ${variantClasses} ${className}`}
+        role="status"
+        aria-live="polite"
+        data-testid="offline-indicator"
+      >
+        <svg
+          className="w-4 h-4 flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3"
+          />
+        </svg>
+        <span className="text-sm font-medium">Offline</span>
+        {cachedEventsCount > 0 && (
+          <span
+            className="bg-white/20 px-1.5 py-0.5 rounded text-xs"
+            aria-label={`${cachedEventsCount} cached events`}
+          >
+            {cachedEventsCount}
+          </span>
+        )}
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="ml-1 p-1 hover:bg-white/20 rounded transition-colors"
+            aria-label="Retry connection"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // Banner variant - full information
+  return (
+    <div
+      className={`${positionClasses} ${variantClasses} ${className}`}
+      role="alert"
+      aria-live="assertive"
+      data-testid="offline-indicator"
+    >
+      <div className="flex items-center gap-3">
+        <svg
+          className="w-5 h-5 flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3"
+          />
+        </svg>
+        <div className="flex flex-col">
+          <span className="font-medium">Offline Mode</span>
+          <span className="text-sm text-white/80">
+            Last online: {offlineDuration}
+            {cachedEventsCount > 0 && ` | ${cachedEventsCount} events cached`}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="px-3 py-1 bg-white/20 hover:bg-white/30 rounded text-sm font-medium transition-colors"
+            aria-label="Retry connection"
+          >
+            Retry
+          </button>
+        )}
+        {dismissible && (
+          <button
+            onClick={handleDismiss}
+            className="p-1 hover:bg-white/20 rounded transition-colors"
+            aria-label="Dismiss offline notification"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/OfflineStatusIndicator.test.tsx
+++ b/frontend/src/components/common/OfflineStatusIndicator.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tests for OfflineStatusIndicator component
+ * @see NEM-3675 - PWA Offline Caching
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import OfflineStatusIndicator from './OfflineStatusIndicator';
+import { useCachedEvents } from '../../hooks/useCachedEvents';
+import { useNetworkStatus } from '../../hooks/useNetworkStatus';
+
+vi.mock('../../hooks/useNetworkStatus', () => ({
+  useNetworkStatus: vi.fn(() => ({
+    isOnline: true,
+    isOffline: false,
+    lastOnlineAt: new Date(),
+    wasOffline: false,
+    clearWasOffline: vi.fn(),
+  })),
+}));
+
+vi.mock('../../hooks/useCachedEvents', () => ({
+  useCachedEvents: vi.fn(() => ({
+    cachedCount: 0,
+    cachedEvents: [],
+    isInitialized: true,
+    error: null,
+    cacheEvent: vi.fn(),
+    loadCachedEvents: vi.fn(),
+    removeCachedEvent: vi.fn(),
+    clearCache: vi.fn(),
+  })),
+}));
+
+describe('OfflineStatusIndicator', () => {
+  const mockUseNetworkStatus = vi.mocked(useNetworkStatus);
+  const mockUseCachedEvents = vi.mocked(useCachedEvents);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseNetworkStatus.mockReturnValue({
+      isOnline: true,
+      isOffline: false,
+      lastOnlineAt: new Date(),
+      wasOffline: false,
+      clearWasOffline: vi.fn(),
+    });
+
+    mockUseCachedEvents.mockReturnValue({
+      cachedCount: 0,
+      cachedEvents: [],
+      isInitialized: true,
+      error: null,
+      cacheEvent: vi.fn(),
+      loadCachedEvents: vi.fn(),
+      removeCachedEvent: vi.fn(),
+      clearCache: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('visibility', () => {
+    it('does not render when online', () => {
+      render(<OfflineStatusIndicator />);
+      expect(screen.queryByTestId('offline-indicator')).not.toBeInTheDocument();
+    });
+
+    it('renders when offline', () => {
+      mockUseNetworkStatus.mockReturnValue({
+        isOnline: false,
+        isOffline: true,
+        lastOnlineAt: new Date(),
+        wasOffline: true,
+        clearWasOffline: vi.fn(),
+      });
+
+      render(<OfflineStatusIndicator />);
+      expect(screen.getByTestId('offline-indicator')).toBeInTheDocument();
+    });
+  });
+
+  describe('cached events', () => {
+    it('displays cached events count', () => {
+      mockUseNetworkStatus.mockReturnValue({
+        isOnline: false,
+        isOffline: true,
+        lastOnlineAt: new Date(),
+        wasOffline: true,
+        clearWasOffline: vi.fn(),
+      });
+
+      mockUseCachedEvents.mockReturnValue({
+        cachedCount: 15,
+        cachedEvents: [],
+        isInitialized: true,
+        error: null,
+        cacheEvent: vi.fn(),
+        loadCachedEvents: vi.fn(),
+        removeCachedEvent: vi.fn(),
+        clearCache: vi.fn(),
+      });
+
+      render(<OfflineStatusIndicator />);
+      expect(screen.getByText(/15 events cached/)).toBeInTheDocument();
+    });
+  });
+
+  describe('retry functionality', () => {
+    beforeEach(() => {
+      mockUseNetworkStatus.mockReturnValue({
+        isOnline: false,
+        isOffline: true,
+        lastOnlineAt: new Date(),
+        wasOffline: true,
+        clearWasOffline: vi.fn(),
+      });
+    });
+
+    it('calls onRetry when provided', () => {
+      const onRetry = vi.fn();
+      render(<OfflineStatusIndicator onRetry={onRetry} />);
+      const retryButton = screen.getByRole('button', { name: /retry/i });
+      fireEvent.click(retryButton);
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows retry button when reloadOnRetry is true', () => {
+      render(<OfflineStatusIndicator reloadOnRetry />);
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/common/OfflineStatusIndicator.tsx
+++ b/frontend/src/components/common/OfflineStatusIndicator.tsx
@@ -1,0 +1,48 @@
+/**
+ * OfflineStatusIndicator component
+ *
+ * A connected component that combines useNetworkStatus and useCachedEvents hooks
+ * with the OfflineIndicator component.
+ *
+ * @module OfflineStatusIndicator
+ * @see NEM-3675 - PWA Offline Caching
+ */
+
+import React, { useCallback } from 'react';
+
+import OfflineIndicator, { type OfflineIndicatorProps } from './OfflineIndicator';
+import { useCachedEvents } from '../../hooks/useCachedEvents';
+import { useNetworkStatus } from '../../hooks/useNetworkStatus';
+
+export interface OfflineStatusIndicatorProps
+  extends Omit<OfflineIndicatorProps, 'isOffline' | 'cachedEventsCount' | 'lastOnlineAt'> {
+  reloadOnRetry?: boolean;
+}
+
+export default function OfflineStatusIndicator({
+  reloadOnRetry = false,
+  onRetry,
+  ...rest
+}: OfflineStatusIndicatorProps): React.ReactElement {
+  const { isOffline, lastOnlineAt } = useNetworkStatus();
+  const { cachedCount } = useCachedEvents();
+
+  const handleRetry = useCallback(() => {
+    if (onRetry) {
+      onRetry();
+    }
+    if (reloadOnRetry) {
+      window.location.reload();
+    }
+  }, [onRetry, reloadOnRetry]);
+
+  return (
+    <OfflineIndicator
+      isOffline={isOffline}
+      cachedEventsCount={cachedCount}
+      lastOnlineAt={lastOnlineAt}
+      onRetry={reloadOnRetry || onRetry ? handleRetry : undefined}
+      {...rest}
+    />
+  );
+}

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -207,3 +207,17 @@ export type {
   ConflictResourceType,
   ConflictAction,
 } from './ConflictResolutionModal';
+
+// PWA offline indicators (NEM-3675)
+export { default as OfflineIndicator } from './OfflineIndicator';
+export type {
+  OfflineIndicatorProps,
+  OfflineIndicatorPosition,
+  OfflineIndicatorVariant,
+} from './OfflineIndicator';
+
+export { default as OfflineStatusIndicator } from './OfflineStatusIndicator';
+export type { OfflineStatusIndicatorProps } from './OfflineStatusIndicator';
+
+export { default as OfflineFallback } from './OfflineFallback';
+export type { OfflineFallbackProps } from './OfflineFallback';

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App';
 import { initializeErrorReporting } from './services/errorReporting';
 import { initRUM } from './services/rum';
 import { initSentry } from './services/sentry';
+import { registerServiceWorker } from './services/serviceWorkerRegistration';
 import './styles/index.css';
 import { isSecureContext, logWebCodecsStatus } from './utils/webcodecs';
 
@@ -35,3 +36,11 @@ ReactDOM.createRoot(rootElement).render(
     <App />
   </React.StrictMode>
 );
+
+// Register PWA service worker for offline caching (NEM-3675)
+// Uses Workbox under the hood via vite-plugin-pwa
+void registerServiceWorker({
+  onError: (error) => {
+    console.warn('Service worker registration failed:', error.message);
+  },
+});

--- a/frontend/src/services/serviceWorkerRegistration.test.ts
+++ b/frontend/src/services/serviceWorkerRegistration.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for Service Worker Registration Module
+ * @see NEM-3675 - PWA Offline Caching
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { getServiceWorkerState, getCacheStorageEstimate } from './serviceWorkerRegistration';
+
+describe('serviceWorkerRegistration', () => {
+  const originalStorage = navigator.storage;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'storage', {
+      value: originalStorage,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe('getServiceWorkerState', () => {
+    it('returns current service worker state', () => {
+      const state = getServiceWorkerState();
+      expect(state).toHaveProperty('isActive');
+      expect(state).toHaveProperty('isUpdateWaiting');
+      expect(state).toHaveProperty('isInstalling');
+      expect(state).toHaveProperty('workbox');
+    });
+
+    it('returns immutable copy of state', () => {
+      const state1 = getServiceWorkerState();
+      const state2 = getServiceWorkerState();
+      expect(state1).not.toBe(state2);
+      expect(state1).toEqual(state2);
+    });
+  });
+
+  describe('getCacheStorageEstimate', () => {
+    it('returns storage estimate with usage percentage', async () => {
+      Object.defineProperty(navigator, 'storage', {
+        value: {
+          estimate: vi.fn().mockResolvedValue({ usage: 1000000, quota: 100000000 }),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const result = await getCacheStorageEstimate();
+      expect(result).toEqual({ usage: 1000000, quota: 100000000, usagePercentage: 1 });
+    });
+
+    it('returns null when storage API not available', async () => {
+      Object.defineProperty(navigator, 'storage', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const result = await getCacheStorageEstimate();
+      expect(result).toBeNull();
+    });
+
+    it('handles zero quota gracefully', async () => {
+      Object.defineProperty(navigator, 'storage', {
+        value: {
+          estimate: vi.fn().mockResolvedValue({ usage: 0, quota: 0 }),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const result = await getCacheStorageEstimate();
+      expect(result).toEqual({ usage: 0, quota: 0, usagePercentage: 0 });
+    });
+  });
+});

--- a/frontend/src/services/serviceWorkerRegistration.ts
+++ b/frontend/src/services/serviceWorkerRegistration.ts
@@ -1,0 +1,258 @@
+/**
+ * Service Worker Registration Module
+ *
+ * Provides utilities for registering and managing the PWA service worker
+ * using Workbox. Integrates with vite-plugin-pwa for seamless SW management.
+ *
+ * @module serviceWorkerRegistration
+ * @see NEM-3675 - PWA Offline Caching
+ */
+
+import { Workbox, messageSW } from 'workbox-window';
+
+/**
+ * Service worker registration configuration
+ */
+export interface ServiceWorkerConfig {
+  /** Callback when a new service worker is installed and waiting */
+  onUpdate?: (registration: ServiceWorkerRegistration) => void;
+  /** Callback when service worker is successfully installed for first time */
+  onSuccess?: (registration: ServiceWorkerRegistration) => void;
+  /** Callback when service worker registration fails */
+  onError?: (error: Error) => void;
+  /** Callback when service worker becomes active */
+  onActivated?: () => void;
+}
+
+/**
+ * Service worker state for external consumers
+ */
+export interface ServiceWorkerState {
+  /** Whether a service worker is currently active */
+  isActive: boolean;
+  /** Whether an update is waiting to be installed */
+  isUpdateWaiting: boolean;
+  /** Whether a service worker is currently installing */
+  isInstalling: boolean;
+  /** Reference to the Workbox instance */
+  workbox: Workbox | null;
+}
+
+// Module-level state
+let workboxInstance: Workbox | null = null;
+let swRegistration: ServiceWorkerRegistration | null = null;
+let isUpdateWaiting = false;
+let isInstalling = false;
+
+/**
+ * Checks if service workers are supported in the current environment
+ * @returns Whether service workers are supported
+ */
+export function isServiceWorkerSupported(): boolean {
+  return 'serviceWorker' in navigator;
+}
+
+/**
+ * Registers the service worker and sets up event listeners
+ *
+ * @param config - Configuration options for callbacks
+ * @returns Promise resolving to true if registration successful, false otherwise
+ *
+ * @example
+ * ```typescript
+ * await registerServiceWorker({
+ *   onSuccess: (reg) => console.log('SW registered'),
+ *   onUpdate: (reg) => showUpdatePrompt(),
+ *   onError: (err) => console.error('SW failed:', err),
+ * });
+ * ```
+ */
+export async function registerServiceWorker(
+  config: ServiceWorkerConfig = {}
+): Promise<boolean> {
+  const { onUpdate, onSuccess, onError, onActivated } = config;
+
+  if (!isServiceWorkerSupported()) {
+    console.warn('Service workers are not supported in this browser');
+    return false;
+  }
+
+  try {
+    // Create Workbox instance
+    workboxInstance = new Workbox('/sw.js', {
+      // Scope to entire app
+      scope: '/',
+    });
+
+    // Handle waiting service worker (update available)
+    workboxInstance.addEventListener('waiting', (event) => {
+      isUpdateWaiting = true;
+      if (event.sw && onUpdate) {
+        // Get the registration from the waiting SW
+        void navigator.serviceWorker.getRegistration().then((registration) => {
+          if (registration) {
+            onUpdate(registration);
+          }
+        });
+      }
+    });
+
+    // Handle service worker installed (first time)
+    workboxInstance.addEventListener('installed', (event) => {
+      if (!event.isUpdate) {
+        void navigator.serviceWorker.getRegistration().then((registration) => {
+          if (registration && onSuccess) {
+            onSuccess(registration);
+          }
+        });
+      }
+    });
+
+    // Handle service worker activated
+    workboxInstance.addEventListener('activated', () => {
+      isInstalling = false;
+      isUpdateWaiting = false;
+      onActivated?.();
+    });
+
+    // Handle service worker controlling the page
+    workboxInstance.addEventListener('controlling', () => {
+      // Service worker is now controlling the page
+    });
+
+    // Handle redundant service worker
+    workboxInstance.addEventListener('redundant', () => {
+      console.warn('Service worker became redundant');
+    });
+
+    // Register the service worker
+    isInstalling = true;
+    const registration = await workboxInstance.register();
+    swRegistration = registration ?? null;
+    isInstalling = false;
+
+    return true;
+  } catch (error) {
+    isInstalling = false;
+    const err = error instanceof Error ? error : new Error(String(error));
+    console.error('Service worker registration failed:', err);
+    onError?.(err);
+    return false;
+  }
+}
+
+/**
+ * Signals the waiting service worker to skip waiting and become active
+ * This will trigger a page reload to load fresh content
+ *
+ * @returns Promise resolving when skip waiting message is sent
+ */
+export async function skipWaiting(): Promise<void> {
+  if (!workboxInstance) {
+    console.warn('No Workbox instance available');
+    return;
+  }
+
+  const registration = await navigator.serviceWorker.getRegistration();
+  if (registration?.waiting) {
+    // Send skip waiting message to the waiting SW
+    await messageSW(registration.waiting, { type: 'SKIP_WAITING' });
+  }
+}
+
+/**
+ * Unregisters all service workers
+ *
+ * @returns Promise resolving to true if unregistration successful
+ */
+export async function unregisterServiceWorker(): Promise<boolean> {
+  if (!isServiceWorkerSupported()) {
+    return false;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration();
+    if (registration) {
+      const result = await registration.unregister();
+      if (result) {
+        workboxInstance = null;
+        swRegistration = null;
+        isUpdateWaiting = false;
+      }
+      return result;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gets the current service worker state
+ *
+ * @returns Current service worker state
+ */
+export function getServiceWorkerState(): ServiceWorkerState {
+  return {
+    isActive: swRegistration?.active !== null && swRegistration?.active !== undefined,
+    isUpdateWaiting,
+    isInstalling,
+    workbox: workboxInstance,
+  };
+}
+
+/**
+ * Checks if a specific URL is cached by the service worker
+ *
+ * @param url - URL to check
+ * @returns Promise resolving to true if cached
+ */
+export async function isCached(url: string): Promise<boolean> {
+  if (!('caches' in window)) {
+    return false;
+  }
+
+  try {
+    const cacheNames = await caches.keys();
+    for (const cacheName of cacheNames) {
+      const cache = await caches.open(cacheName);
+      const response = await cache.match(url);
+      if (response) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gets cache storage estimate
+ *
+ * @returns Promise resolving to storage estimate or null if not available
+ */
+export async function getCacheStorageEstimate(): Promise<{
+  usage: number;
+  quota: number;
+  usagePercentage: number;
+} | null> {
+  if (!navigator.storage?.estimate) {
+    return null;
+  }
+
+  try {
+    const estimate = await navigator.storage.estimate();
+    const usage = estimate.usage ?? 0;
+    const quota = estimate.quota ?? 0;
+    const usagePercentage = quota > 0 ? Math.round((usage / quota) * 100) : 0;
+
+    return {
+      usage,
+      quota,
+      usagePercentage,
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Add PWA offline caching infrastructure using Workbox for service worker management
- Create OfflineIndicator component with banner, badge, and minimal variants for showing offline status
- Create OfflineStatusIndicator connected component that uses useNetworkStatus and useCachedEvents hooks
- Register service worker in main.tsx for automatic offline caching
- Integrates with existing vite-plugin-pwa configuration

## Test plan

- [ ] Verify OfflineIndicator renders correctly in all three variants (banner, badge, minimal)
- [ ] Verify OfflineStatusIndicator appears when network goes offline
- [ ] Verify cached events count is displayed correctly
- [ ] Verify "last online" time updates every minute
- [ ] Verify retry button triggers page reload when reloadOnRetry is true
- [ ] Verify dismiss functionality works for dismissible indicators
- [ ] Run `cd frontend && npm test -- --run src/components/common/OfflineIndicator.test.tsx src/components/common/OfflineStatusIndicator.test.tsx src/services/serviceWorkerRegistration.test.ts`

Generated with [Claude Code](https://claude.com/claude-code)