### PR TITLE
fix: lower Nemotron temperature for consistent risk scoring (NEM-3734)

### DIFF
--- a/backend/services/nemotron_analyzer.py
+++ b/backend/services/nemotron_analyzer.py
@@ -679,7 +679,7 @@ class NemotronAnalyzer:
 
         payload = {
             "prompt": context,
-            "temperature": 0.7,
+            "temperature": 0.3,
             "top_p": 0.95,
             "max_tokens": max_output_tokens,
             "stop": ["<|im_end|>", "<|im_start|>"],
@@ -2989,7 +2989,7 @@ class NemotronAnalyzer:
         # Nemotron-3-Nano uses ChatML format with <|im_end|> as message terminator
         payload: dict[str, Any] = {
             "prompt": prompt,
-            "temperature": 0.7,  # Slightly creative for detailed reasoning
+            "temperature": 0.3,  # Low temperature for consistent risk scoring (NEM-3734)
             "top_p": 0.95,
             "max_tokens": max_output_tokens,  # Use settings-based value
             "stop": ["<|im_end|>", "<|im_start|>"],


### PR DESCRIPTION
## Summary
- Reduce LLM temperature from 0.7 to 0.3 for more deterministic risk assessments
- Lower temperature ensures similar scenarios receive consistent risk scores
- References NEM-3734 (Optimize Inference Parameters from NVIDIA Recommendations)

## Changes
- `backend/services/nemotron_analyzer.py`: Updated temperature from 0.7 to 0.3 in two locations

## Test plan
- [x] All 123 nemotron analyzer unit tests pass
- [x] Pre-commit hooks pass
- [x] Pre-push smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)