### PR TITLE
fix: remove duplicate ai-yolo26-metrics job from prometheus config

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1111,7 +1111,7 @@ services:
   alloy:
     image: docker.io/grafana/alloy:v1.0.0
     container_name: alloy
-    privileged: true  # Required for eBPF operations with Podman
+    privileged: true # Required for eBPF operations with Podman
     # Use specific capabilities instead of privileged mode for eBPF
     # CAP_SYS_ADMIN: Required for BPF operations
     # CAP_SYS_PTRACE: Required for process tracing

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -147,24 +147,6 @@ scrape_configs:
 
   # YOLO26 TensorRT Object Detection metrics (ai-yolo26)
   # Alternative detector to YOLO26 with 5.3x faster inference
-  # Key metrics:
-  # - yolo26_inference_requests_total: Total inference requests by endpoint/status
-  # - yolo26_inference_latency_seconds: Inference latency histogram
-  # - yolo26_detections_per_image: Number of detections per image
-  # - yolo26_model_loaded: Model status (1=loaded)
-  # - yolo26_gpu_*: GPU utilization, memory, temperature, power
-  - job_name: 'ai-yolo26-metrics'
-    metrics_path: /metrics
-    scrape_interval: 15s
-    scrape_timeout: 10s
-    static_configs:
-      - targets:
-          - 'ai-yolo26:8095'
-        labels:
-          service: yolo26
-          model_type: detection
-    honor_labels: true
-
   # ==========================================================================
   # JSON Exporter Scraped Endpoints (For non-Prometheus format data)
   # ==========================================================================


### PR DESCRIPTION
## Summary
- Removes duplicate `ai-yolo26-metrics` scrape job from prometheus.yml that was causing Prometheus to crash on startup

## Test plan
- [x] Prometheus container starts and stays healthy
- [x] All other containers healthy after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)