### PR TITLE
fix(redeploy): fix bash line continuation and cleanup logic

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1567,21 +1567,21 @@
         "filename": "docs/development/hooks.md",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 425
+        "line_number": 583
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/development/hooks.md",
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_verified": false,
-        "line_number": 448
+        "line_number": 606
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/development/hooks.md",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 510
+        "line_number": 668
       }
     ],
     "docs/openapi.json": [
@@ -1696,6 +1696,50 @@
         "line_number": 254
       }
     ],
+    "scripts/redeploy.sh": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/redeploy.sh",
+        "hashed_secret": "7695539086cb993e94d8c3f48d6bdd044f176aa2",
+        "is_verified": false,
+        "line_number": 502
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/redeploy.sh",
+        "hashed_secret": "bb1c6364c80212583ebb73aa6470dd308fad9d68",
+        "is_verified": false,
+        "line_number": 515
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/redeploy.sh",
+        "hashed_secret": "f0c296a3e43ab25fb16e24de75751c72394b12af",
+        "is_verified": false,
+        "line_number": 531
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/redeploy.sh",
+        "hashed_secret": "41a7e38edafecede07c435bf489b37de0a6fd1f1",
+        "is_verified": false,
+        "line_number": 532
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/redeploy.sh",
+        "hashed_secret": "08376ebb1440478f4b1de8ad67464581090f1004",
+        "is_verified": false,
+        "line_number": 533
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/redeploy.sh",
+        "hashed_secret": "fdc5b709553d5a4cc469eaee2669869a7f239178",
+        "is_verified": false,
+        "line_number": 534
+      }
+    ],
     "scripts/test-in-container.sh": [
       {
         "type": "Basic Auth Credentials",
@@ -1745,5 +1789,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-28T17:31:01Z"
+  "generated_at": "2026-01-29T19:24:50Z"
 }


### PR DESCRIPTION
## Summary
- Remove inline comments after backslashes that broke bash line continuation
- Add cleanup of prod compose containers for podman (was only stopping GHCR)
- Add pre-cleanup step before starting AI containers
- Add pre-cleanup step before starting backend/frontend containers

## Test plan
- [x] Script syntax validated
- [ ] Full redeploy tested locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)