### PR TITLE
feat: restore and migrate Cosmos synthetic videos to category structure

### DIFF
--- a/data/synthetic/cosmos/.gitattributes
+++ b/data/synthetic/cosmos/.gitattributes
@@ -1,0 +1,1 @@
+*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E01/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E01/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0a514b612f19349319b0b302255d01c51cafe33dc3d6e00c4590dabcb3b5e77
+size 3071698

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E02/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E02/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f7267bd20b94119ca3df820eda7ad6a2d108c588c501839ff30e42c59bae6ed
+size 4261898

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E03/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E03/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87b53edb24f4bee59031f1f749d7b14080c01bca6fd200e458fe8261f2887ac7
+size 5059149

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E04/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E04/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f958ef39749203d109ad1aad23c4b68d28de67ae4535bc2d0677bc60d4f0fdc
+size 4424704

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E05/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E05/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8d2c37810ee37bf21fcf82346fc9ac0dd26e0b449ae4ffec8d9f613e0052470
+size 3486771

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E06/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E06/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b56b1c96eaa9fc2830343c012d02c4cc513e32e84385fd7e6543744eed0b3048
+size 3130998

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E07/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E07/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa92ada27342550d8148098281d6c6d176d644441f13dbe49d1a8ce4eaa3eee7
+size 3556999

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E08/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E08/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7ccd368da4c2d729def00c9f6a223c7befd19b4bfb88d040bad50e5be9ec25e
+size 6258205

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E09/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E09/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4550abf24d70647decda0b2a4bdae5f58a76914f2f80b251450f6eee15b4c8f6
+size 3367199

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E10/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E10/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9112acb9420406533ba636f5d6f1152e69a43feb8fda629e0072ad64e869ae5
+size 4081111

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E11/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E11/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ce6aee8ee9c816889d352958f2e7b958a5d56e7e40ba7cb3338da92a6f40902
+size 4680031

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E12/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E12/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:228484b957519719ae869bbecf5674b0588cddeb53bd05c45554a6464e224ac7
+size 4204736

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E13/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E13/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be8674a99515dca8a1706317a163e6079691aabcbb46cbe25f0536c2a97ddfb6
+size 7342956

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E14/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E14/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0adb38e4d3f4c0695efc3ce27195de89a9cb91ba5c94bc6f7a496ae43c8a48c
+size 4218128

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E15/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E15/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:021f8ae5144ff84597d694d89eff168813efb05dc8cf0e7303a6818b73b7eb18
+size 3259773

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E16/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E16/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:050493455c0f33b78cf4962ca5cbd98957071939353739b529806688d5e62a92
+size 3041415

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E17/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E17/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:181feb9cb2fee6a4b86e570e5a5b3c26d2901701f13aa5ca8da6862a4ffc1b29
+size 3967868

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E18/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E18/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14257ca784070606e5d2f8646a270482809e0b97e0f673a166958be773159a06
+size 6538808

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E19/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E19/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e0359f41af803fe29d3b8793b79cf046bc573bd4265ed0378b67e94a9521c7e
+size 4394368

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E20/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E20/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1436cea068139a3a74786d03012656786256f8f125f1b4f4c0d3c5d3c46b12de
+size 4106850

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E21/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E21/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8a81e22fc339a832f06883b8a4d03a39715ef9fead47ae5fd4d8afc6b756668
+size 3092799

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_E22/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_E22/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5834f719686cc7fbb4fbe13bcd50184c3e76fb4bc9b54e22ceacc711602bc852
+size 4069200

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F01/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F01/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:330c5d8ebb6e183c05e080d28289be140479956a4644ba4ee9ec42547e14bf66
+size 3255204

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F02/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F02/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8bc5d1b8bad025e511ea6444a424cff8fd1f31af5764880c1322177c8d7e17d
+size 619084

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F03/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F03/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76d3d4abb3324872a3bc9ff8957cd369320c43aae184a3f1d431b68ce7dd44d9
+size 771814

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F04/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F04/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff3e70425d63beb7fcf365d0e6fc6eadc5da8878435b209335ad57b05a2293fd
+size 391731

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F05/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F05/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d2c8d706179ffc8590f16fe00e6b2591382e949e2f979ec750fb19885899da9
+size 4435599

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F06/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F06/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:332f1093a86ad8bf079cd31fe388dfa80cb97b8b605c5a790bfb1d41198adc3e
+size 1605218

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F07/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F07/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a79521b05dce84073043ae24d992731a74294ffc63eaa50e70b1941ecaf2448
+size 5623501

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F08/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F08/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62e39afeab793c5ed6bb625bbf677dc68a13c148fbcaf2b5b77436bff6fc5586
+size 4100608

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F09/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F09/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b19ec43fd22f8074380a6decb2e968a5c413f589816fe95f6e0438dac323824
+size 366810

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F10/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F10/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e0ce060cabfc6314f0bd0ea1a7c7dfe04e2bc0b2ce12cbf10a932825f443d1e
+size 2787101

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F11/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F11/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a67d87f2e25806015e14f8b9b336b6237d2f0d1ff601c5c4afb022def3f6610a
+size 1597837

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F12/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F12/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:806dbc3b6ef0f2dd447f0b12308f6e912d4c06b7a5cc1638d9188c46cb06d9f7
+size 4304873

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F13/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F13/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08cc67a39a57b53bf52bad66b1f2d98ae0329c5c26fc66e39ab182b66a6d15d7
+size 5230896

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F14/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F14/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cca0e2df99ad33baa08cc296b54eb5b1d43d425ca90b78385773cccc30928686
+size 4822183

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F15/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F15/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dfb4286b2a46696d48a60f68bea55bd13a9641855f1459bf5749c6648d1ae58
+size 3864564

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_F16/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_F16/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b2a67f08bd60e5c538941f6324ad461623445ea86c3f4e4f6ee8cbeda123108
+size 3520596

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P01/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P01/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8273e7bfd0ec493cf75bab99cbc9cdc279d475000dc1352af6ccffd2fb6f57a0
+size 516272

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P25/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P25/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0598ceb1bda187425e67b768678e55e058b7d822a0c7efa416fcdb58c5da6cc
+size 2564601

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P26/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P26/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80de47708f0ae80e78a782e157e5d385e27ee0a503856c8392b987cd5c71742e
+size 2039000

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P27/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P27/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be3a8b3e2e2e1ea19244075cccf74b9279af8d1c270145ff2380c993d20feab4
+size 2454624

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P28/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P28/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e0d982f32a8c20ce7a96f0de67dc84afd8aa7c03750458f22844dd673081b09
+size 1766494

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P29/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P29/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0c1cfc9f2220e6c0ede9e64258dc51d2c00438e2481f42ec3cfe17cfafc9a7c
+size 2548960

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P30/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P30/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1edd2d7ad3b47e755c07b28b46f5b261c7b80a8df73f5f7a2fe26300a2c517f2
+size 1972512

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P31/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P31/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76d9dca74c48dfc657203f0f8be1d85441330e2ee07a47e368206dbe816be6c0
+size 5698159

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P32/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P32/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4df1ac50e870ecb29639b24d1f9e50172bc5c183a41ed7c816db5767a549c14
+size 5062538

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P33/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P33/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c932a45bfe3b925d0c53a638794ad19b9a5d4d36e9e2a72f77f3b8896d4a5298
+size 2388347

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P34/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P34/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8db89e6da22dc17e6f4d9f22282439b51a9390d75a24aeaa28a0dee1e09172ad
+size 2117131

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P35/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P35/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac2f5c155c018950d5e3adf33ce7eb749623b7bee12a4ade1ace5e9e43f7f4b7
+size 5435084

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P38/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P38/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d26b9f9d2b9831f3f354a7d27c8393f1d729682e94d2804e5382b444f744ad89
+size 4333691

--- a/data/synthetic/cosmos/data/synthetic/normal/cosmos_P47/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/normal/cosmos_P47/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e5bf9859aa84459306b7850cb30e9cbd12a4ab9cab28946591cda17f23a2008
+size 6234547

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C01/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C01/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4429563316346c16e5b914b7bd03866fa1b4cbff73db2a3fb4ae274a57fd880
+size 643057

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C02/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C02/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1170980d9480acad72aab47a6c297ab48f303070665ed3e53e336e0a8ec64825
+size 1979201

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C03/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C03/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13104dfc01bb3e48789a037cab5be421e1822c4af1ba97ff232c20283cb56439
+size 743430

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C04/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C04/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d60dd1245d47cff61b89680d40b13b4569e31d3435c6c217726c7eb238fb4fd
+size 6388379

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C05/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C05/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a979b047d2356164aadccd666c0cad5424cfca9d6728b333915531ebd7354eb5
+size 2380171

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C06/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C06/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68b388136607f9d6a77811eae63f9a574120e611420c57ab4eef48ce91f60463
+size 2071722

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C07/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C07/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed65c68be13de56e56777dcd6dc956d4389dbab3374d976578d36e518f9ec872
+size 249940

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C08/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C08/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:accf8cf9767085185f1981d2941f7306d0142a07f153a4e1e9ecdae160cfca5d
+size 284139

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C09/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C09/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c84444408171d8bb69d0568a5ba9cc0855da7bfbd62f6a146d5d88ae64e560ba
+size 451033

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C10/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C10/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:364275a270fc56169e7dd55dc1c39fdb03b8738b9b14bb95f41cf5bea4a29172
+size 473242

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C11/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C11/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca065f9c86ee2bdc0bfa4d3b559de16c2ca58904218d0eee915a9470eeeb7a63
+size 600040

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C12/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C12/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9861cb1d40d852fe8a5420d925d9c5d1db09aea5c914a2c0d8ef247f8f8a5fd
+size 2721381

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C13/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C13/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edfe35613d2643e317e25e4e5741f6c5af5cce3323299996eedcc740e528445c
+size 4624491

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C14/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C14/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8df52ff316045a3a98b9621b53f7ef1fd6570d6cbcb6a1df5147b5884d41127
+size 4590922

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C15/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C15/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4af4bfb9f9f0ec3d01dbf8af7b7b6805609058580d62dba8415568c5fc836bed
+size 3449201

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C16/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C16/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:784a74595cd47b537e0a1efe42e68216742faf0891c5e96409d1a370f6874418
+size 3275661

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C17/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C17/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fbdfe3d7915d376419053927f3c5e958e75e9f875b16dc45c6862166be2e848
+size 823382

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C18/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C18/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ceaf4c9ca88eea87f32d4d7408aed6c322d5ba634659dfee8d129da364904182
+size 2490296

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C19/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C19/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d55287a7fa2dfe5a72277479954e428d98250fca399c10d9a3ed139743bd5015
+size 444906

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C20/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C20/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2a04509bb62cea57692be54a50ac2ece67786b9d81b1d9f5667497d2f34db16
+size 3605835

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C21/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C21/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a162737107169c898354e81a18507eb22e20007e4308402232ae24fd3b7e441
+size 5916330

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C22/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C22/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0a4647cb2e59e04012a84c658d32943b0cfbc6d79fcd9c196581440627b768b
+size 7020188

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C23/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_C23/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b7b99a9bba964319829c5be5f30151c1d4201f7d406c60ca4098c722cc655e7
+size 3631926

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P02/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P02/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:572304cff817f93501bd724894608d1669b8205f4e649113823f0b042e643747
+size 384377

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P03/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P03/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:200e8d0d6d61a46d09b621c84f942180d5c105f8f9bb4060aec9c61c1596f996
+size 368344

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P04/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P04/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a782832b4f6eacab2959001c0e5d73a80e2d4309eb9150a69186682182d477c1
+size 346752

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P05/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P05/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f1fc169a7552afe702ac21c3490ee317d55d43b5da22aba0ddd1ce81e894683
+size 267286

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P06/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P06/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6faf1becd7d6c4644d356350a0b2022f27267d16223b241565f683efcb057d60
+size 355001

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P10/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P10/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7dc826d06dbcbf8f23fe1ad11b227fe5ee7e1f43acbbfc149925c0b6eba3d10
+size 386538

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P12/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P12/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c632c406666d343ecd9c3ae9b9f84808ccc09ee8ba17cc59674cdd61be88da04
+size 392095

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P13/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P13/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aec7534294485d89435521e1aee8dc354861c7315ebab6b5b7c596abebde838e
+size 1643432

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P14/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P14/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9aec11780399916ac7e659c9076a928077140f1d3fa9b2d67ce15848b56369c
+size 1212625

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P15/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P15/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5c712ad938dc5fb81d78e660946b063b655a58e625d3e6abdd54b34f1d991d5
+size 1783480

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P16/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P16/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91791f50fc6d27f41c5488f90d2d106c5a86db6876987279670aed1c4d76942e
+size 1212736

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P17/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P17/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2efcc559bf3a1e6860c80137b5ee6e0c393ebbd19ce08f3b1de80554f70a34c9
+size 842356

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P18/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P18/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfa8d6ab4e37c4ffe2eee465422fb0456b2a0793b148352dec22bb94133339ca
+size 870926

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P19/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P19/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a70aaefb52d4890e63d807406f97f202649392be671bccb894e27848f5edd3fb
+size 1094416

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P20/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P20/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5370aef369538f05c77386fdda436e9ebfa017860f6172a855d4ceee4be99d6a
+size 2137133

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P22/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P22/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b9ebc64b6573d773599f5647f58bd2c06c518ef7abe8a442d210c60c451c868
+size 1298995

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P23/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P23/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aec235355f2a4072a83b2f2a474fc276e86902311e3b6ab32a8e7ed6c64e6e5
+size 2049320

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P24/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P24/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c339c86e0a1682fcd1f6e52ce9568927b7a9399e219b83e40eefe46b1465a856
+size 1529542

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P36/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P36/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be09b07469f910fbf4448ab9393ba494cac7ac60a942061ce36cc1809206d216
+size 5684178

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P37/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P37/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:258350898a6b078f3cd02bb43937496ad1c49d865ae9505a568799a31d0c4673
+size 5506216

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P39/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P39/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5983b3df09615e4a286b01f19a46029e23243cdf7f2c8e460bd2bb8fbf767427
+size 6053857

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P40/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P40/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb6734d61562a3fef144aa1e4e37c0230ff92e6ce4140844dd08827d03f672ff
+size 3762488

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P41/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P41/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:934564f32ee4deb6c59011862c9f9003b845cdada41061aedb45e71cce153de8
+size 4955539

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P42/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P42/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90a1d051dfa39a5420359004b72f4f0dbc04df2338b250fa850550786af9aad3
+size 5360948

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P43/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P43/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1a620d8e5d05a72d9f7dfe738343c51277401d1760eed7717abc781411f5111
+size 5066352

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P44/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P44/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc3376ad7623ecd810dbebd56322570180e950fb7f101dd9d3d7329846e7a98f
+size 5695279

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P45/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P45/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a10119f67d16a42643d38021942b75dd5f9a00362a09ff6ba79e421c2306094
+size 5171757

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P46/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P46/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea15d6294f74da3ecc721ba995c9f7ea8820c71b920ccc5bff9ffd16c7615ef1
+size 9088245

--- a/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P48/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/suspicious/cosmos_P48/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f79207dfb1f61760da29a56046bb61f41f12e36a0ec6f7f94854e60100fe6e79
+size 642110

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_P07/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_P07/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d33d9095fd08e56afaa8696272d8f894701e1a560b5b34609f7c1ff988ed661
+size 347560

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_P08/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_P08/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ee68ca156484c376e9c1f06088451a6bd92e5ad7afdd6094f960ffe4b30d268
+size 516408

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_P09/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_P09/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:440e4bccb642ddda2490313afcabd92c611536c1bf907deb7754bab384d9f7f3
+size 431010

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_P11/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_P11/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a23653ff054f09ffa63cf96d557ebe86f8a1f9f9deb000a2b6ad94b296be3d5a
+size 717272

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_P21/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_P21/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4bc0af948b2ddb62114f2b867a398d4791192a501e08d7c1d49ae579b8dc0d6
+size 829176

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R01/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R01/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f9dc9e21bf6a0744b4141f0c4c3bb4f533a9d6777b9b6e15599cfcf36b3a7f3
+size 3590873

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R02/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R02/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f02a131b7ec4fc5a517ad74dc771e5a5010a62e1f3aa8c75f49f8f0bf069d724
+size 4178745

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R03/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R03/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d44b2202a8dcdd13aadc8b4f83a0b175e40166f7f322052d3a20584ae1cd860
+size 4169311

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R04/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R04/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fa6aa38070d43fba37004d7eaa8ab76ee4758f9a4b81535a918c9f32c2487a4
+size 326542

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R05/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R05/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0aca77b7077ec4a5fbb2a85f1dd6040dd0cf0cff8ac23ed265d4e34ab4bba446
+size 284427

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R06/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R06/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:738af83cdf01af88c77ce248d1a5d72e7a85d756853f07d460018eed672a5ab6
+size 468924

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R07/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R07/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86fbe7611270b5d42ff0a80a6bdf1e9b7431a93e2419334bcffff2c6010ab202
+size 515932

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R08/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R08/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1418b076b2cc85b14d0a8654aa8485798695d364dc652fad424919bf99c4a8fa
+size 595799

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R09/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R09/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1ea0910c2da2839da17eeaf66ff5690b4f2fc721b32a6fd558ce02ea9bd76c4
+size 338894

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R10/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R10/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:206cc921e7dbe8dae0918042a9c32d46994c3da533f8ed5fc4fab30aaa455489
+size 830766

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R11/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R11/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da8126805166579b080767d031219cbcd381ce5ab29f79e703e9f08e32810b5e
+size 5424242

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R12/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R12/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5435d932b3b99a7275daf52736242f4f54676ba8d05310e9c67b65c5a80996c6
+size 4347854

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R13/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R13/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd0a817a370dee66848ad61251f1310c9d75330161e954c87de61a2b4dfc265a
+size 307643

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R14/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R14/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d31caf2a6a9e7393e52033a4c7aec50924da9653eb0c32d185d980edc39405e
+size 497227

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R15/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R15/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93f2fc03e850f5b8020cea3878817586edff2d448e7c29e0d1dda060876b6575
+size 412238

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R16/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R16/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45b2838c9d518829e5fd3984fd476d508176c6331faf4276e551f31e87c622a2
+size 470616

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R17/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R17/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0da09ab55e3cd6ce336ac313e9af47061c48b4244cd79525e949d25fe1a85af5
+size 4211321

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_R18/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_R18/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2da5b1b3c65517cd2c02fd41a77a3cbca01624a64ac86ffb9ba04fc9d04ec5ff
+size 438438

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T01/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T01/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdad1cf3d0564bed166855bac39fc75f84566fc18e0a2b5b5ec8ec1b9ff50940
+size 298713

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T02/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T02/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71242d01f9a863cafcaec3d19534f3b37b0b7bfb2b581ae2cf68a6da6890ce9a
+size 234131

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T03/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T03/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfca8da510a111adbd737f75ed0d968af5cc0b37b6a9660781ae5401f51992a5
+size 476736

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T04/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T04/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49b38f37e3412d435ca6ebd01dc1353702185a250bc0cca19305ac55ea986bab
+size 340597

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T05/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T05/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a82e5b311bdae957a13c7fc3fb46cdbf701f574f469d3cbea01a6eeb57a3d8df
+size 372833

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T06/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T06/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9fb0859ee447415a6959ec505fed784a6d35960e7d17c270fc9b381334a951
+size 337993

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T07/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T07/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2735b7b173e5d732a9a31da5a1869c3ff5cb95b02a6bbf7d047433b9268dc53d
+size 322441

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T08/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T08/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b07dd5dad5459b901cf3bbef7d8b8f36055be3442883b106b2ac52b0df65930
+size 154444

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T09/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T09/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed9bf649914e3419bbf72091617fd88198b3b36e33b7776e2b3a14263f6d0aa0
+size 269386

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T10/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T10/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c0c0f81a498ba68d417da86d9687efe7816ac5ea1b283527e28c49ef4da2764
+size 233565

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T11/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T11/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:671a5ab6f8d1dbc233074a91746d4fb5f5cf2d0541ee1e02a3c1ebe01c3d9ecf
+size 4994292

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T12/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T12/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a11b59f2f75f7981d4f38b6c7893deb4b5102966cadd9b39c75c7fd51c2cafdd
+size 5740891

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T13/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T13/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7cde294436003981e253693202ec3c489375889a5703d07ffe8f6165b04fee6
+size 2912604

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T14/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T14/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dab7597459da45b15b82647ce4c2e14928439355a730585d201d9369b2fc0592
+size 4542981

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T15/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T15/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8b6cb835602ab547cc8dee00bb7c2071571fc19271b35c534197e0c935fedf1
+size 6415688

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T16/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T16/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:562b548e7b99eb16dee380d5e67177d141141c0b09096412c0943ac621da1ce9
+size 6169651

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T17/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T17/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b9b7970bf97d5ba7f0cc07abf1951fe8df298f6fdc1a0f2c30484776d172bc8
+size 5129322

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T18/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T18/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a23c6f52ec3205142b73e4723a6f29317d8d4b0414593141d46b5a2218209326
+size 5568833

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T19/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T19/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:724ed1c5062d3cdf1e3fb02347c93f3416172be64338a7d5a4dbac702c3e24c3
+size 7335339

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T20/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T20/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:beabbfda3550edf7992cb91100a4dac9786531202115e8ab5bf3ba736e5410bd
+size 2002096

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T21/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T21/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e2c62f3319994c01ab6b8263d535fe2ebae3dc353df83faa096cc8087b979dd
+size 3488732

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T22/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T22/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1b644d031d06fccd471e8eb5628a969be9fa07e0a60a2031f5434c90b9ee04b
+size 4280927

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T23/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T23/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fe268eab3108c221460859b048f015f3c6db33c8d4565251a4a468112296230
+size 3849463

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T24/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T24/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff47ddb51fbff35dff8120f3815bb6037a3aab2aa7ba7a62f78f56c70ef1149f
+size 4596045

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T25/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T25/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9372093715cebe2b10387e92a4299a4e5544ea2c254b8567593fc103f9971daf
+size 6703799

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T26/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T26/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:755abcb5627f543611957bf8be078dd55e2cdb0fdfa47f7c55e0536048421654
+size 4732865

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T27/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T27/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56511c4417b757bc49b015148d7061916ec4f3bf1863130bb65d2dc9f4c0bb5c
+size 6681230

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T28/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T28/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5f85417487a5db29e4973fc1a3e4f634997268f72cd540d78504c93b6396962
+size 5826829

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T29/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T29/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28ca2e9a6f70a33b7bca8e30a608f4d0d43c2b9a39b5f309da06203d7167e523
+size 3872078

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T30/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T30/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:821ace807143ae5e8643b43acf125bddfab8ed85aace18c9e216435542781303
+size 4002120

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T31/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T31/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cce6792d1ce0b401d8dca8c900ca5471ee586066a2343ea192862f686923923
+size 343439

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T32/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T32/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edcbb145dbe9bc61f5cce0660ba8a18a7a97a8d98ce4eb5ff1ea6aab12fc39cb
+size 711255

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T33/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T33/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f395e81b5442923fd190acb155486f8306dcbb47d33306383e85f2e439fd3471
+size 427405

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T34/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T34/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:183dffb14d6aafa352c9dfc89809e3e07e221497007ebb2561c0b49feb125133
+size 3472453

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T35/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T35/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d30f7324d7e0ef5d11cb0fd52db47fde5b46597c9ff0be33f70fd017946ec488
+size 5203493

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T36/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T36/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e69b475b7251f496088a5cf3e5e7a6ddada1443272c29122b3b67a9ca70fbd3
+size 231411

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T37/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T37/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:611c138019769e2e6bfde5dd2d6ceceb14cb6c816fbbad452f48f26bc91347f9
+size 315594

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T38/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T38/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01223d3fc10b5c4c014aa3062b19eddac003fc1edffd47c65d9742277d37cb92
+size 1798888

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T39/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T39/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f28d9e5551ac13f31574686129f9fe219fa110dba17aad979c1b65968054da3e
+size 824708

--- a/data/synthetic/cosmos/data/synthetic/threats/cosmos_T40/media/001.mp4
+++ b/data/synthetic/cosmos/data/synthetic/threats/cosmos_T40/media/001.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79ea9847bb4ad768111bdf199d78c1532992e4a51726dea3b5d66a8b2c57f768
+size 541303


### PR DESCRIPTION
## Summary

- Restored 167 NVIDIA Cosmos-generated security videos from Git LFS cache
- Migrated videos to standard synthetic data structure by risk category
- Added .gitattributes for LFS tracking of MP4 files
- Updated .gitignore to allow MP4 files in data/synthetic/

## Video Distribution

| Category | Count | Series |
|----------|-------|--------|
| normal | 52 | E01-E22 (deliveries), F01-F16 (wildlife/false alarms), P01, P25-P35, P38, P47 |
| suspicious | 52 | C01-C23 (core detection), P02-P06, P10, P12-P20, P22-P24, P36-P48 subset |
| threats | 63 | R01-R18 (risk scenarios), T01-T40 (threat training), P07-P09, P11, P21 |

Each video is ~5.8 seconds, stored as `media/001.mp4` in category folders.

## Test plan

- [x] Verified video file integrity (valid MP4 format)
- [x] Verified LFS tracking configured
- [x] Verified category distribution matches VIDEO_CATEGORY_MAPPING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)