### PR TITLE
fix: cap pytest-xdist workers to prevent system lockup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -429,7 +429,7 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "-n auto --dist=worksteal -v --strict-markers --tb=short -p randomly"
+addopts = "-n 8 --dist=worksteal -v --strict-markers --tb=short -p randomly"
 timeout = 5
 timeout_method = "thread"
 timeout_func_only = true  # Only timeout test functions, not fixture setup/teardown (prevents pytest-rerunfailures server thread from being killed)


### PR DESCRIPTION
## Summary

- Cap pytest-xdist workers from `-n auto` to `-n 8` to prevent system lockup on high-core Linux workstations

## Problem

On high-core Linux workstations (32+ cores), `-n auto` spawns workers equal to CPU count. Each worker creates its own PostgreSQL test database, causing:

- 30+ concurrent database connections with DDL operations
- Worker crashes from resource contention and timeouts  
- systemd resource deadlock (`Failed to start session scope: Resource deadlock avoided`)
- Complete system unresponsiveness (SSH unreachable, requires hard reboot)

## Solution

Cap at 8 workers which provides good parallelization while preventing resource exhaustion. Users can override locally with `pytest -n <num>` if needed.

## Test plan

- [x] Verified change in `pyproject.toml`
- [ ] CI passes
- [ ] Test on Linux workstation with high core count

🤖 Generated with [Claude Code](https://claude.com/claude-code)