### PR TITLE
fix: add 'ci' to valid environment values for docs workflow

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -2781,7 +2781,7 @@ class Settings(BaseSettings):
     @classmethod
     def validate_environment(cls, v: str) -> str:
         """Validate environment is a known value."""
-        valid_environments = {"production", "staging", "development", "dev", "prod", "test"}
+        valid_environments = {"production", "staging", "development", "dev", "prod", "test", "ci"}
         v_lower = v.lower()
         if v_lower not in valid_environments:
             raise ValueError(


### PR DESCRIPTION
## Summary

- Add `ci` to the valid `environment` field values in `Settings` config
- The GitHub Pages docs workflow sets `ENVIRONMENT=ci` but the field validator rejected it, causing every docs deployment to fail with a `ValidationError`

## Test plan

- [ ] Docs workflow passes on this branch
- [ ] GitHub Pages deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)