### PR TITLE
fix: Prometheus cadvisor target, CDI GPU passthrough, frontend read_only, auth cache

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -399,10 +399,11 @@ scrape_configs:
     scrape_interval: 15s
     scrape_timeout: 10s
     static_configs:
-      # cAdvisor runs in the rootless compose network (privileged mode for cgroups v2).
-      # Use the internal container name and port (8080) directly.
+      # cAdvisor runs as a rootful systemd service (not in the compose network).
+      # Use host.containers.internal to reach the host from inside Podman containers.
+      # Port 8088 matches the -port flag in monitoring/cadvisor/cadvisor.service.
       - targets:
-          - 'cadvisor:8080'
+          - 'host.containers.internal:8088'
     # Filter to only include containers from this compose project
     # and add helpful labels
     relabel_configs:


### PR DESCRIPTION
## Summary
- **Prometheus**: Fix cadvisor scrape target — use `host.containers.internal:8088` instead of container DNS (cadvisor runs as rootful systemd service, not in compose network). 26/26 targets now UP.
- **AI Gateway**: Pass all GPUs via CDI (`nvidia.com/gpu=all`) + `CUDA_VISIBLE_DEVICES=1` — fixes Triton CUDA initialization failure. 13/13 models now loaded.
- **Frontend**: Remove `read_only: true` — nginx entrypoint uses `sed -i` on config and generates SSL certs at runtime.
- **Auth**: Use `refetchQueries` instead of `invalidateQueries` after registration to prevent stale setup cache race condition.

## Test plan
- [x] AI Gateway: 13/13 models loaded, healthy
- [x] Prometheus: 26/26 targets UP (including cadvisor)
- [x] Frontend: serving dashboard, no read_only crash
- [x] Auth: registration followed by immediate navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)